### PR TITLE
Fix direct upload to use account-scoped endpoint

### DIFF
--- a/lib/fizzy/client.rb
+++ b/lib/fizzy/client.rb
@@ -71,7 +71,7 @@ module Fizzy
         }
       }
 
-      upload_info = post("/rails/active_storage/direct_uploads", blob_params)
+      upload_info = post(account_path("/rails/active_storage/direct_uploads"), blob_params)
       raise Fizzy::Error, "Failed to create direct upload" unless upload_info && upload_info[:data]
 
       data = upload_info[:data]

--- a/test/fizzy/commands/upload_test.rb
+++ b/test/fizzy/commands/upload_test.rb
@@ -36,7 +36,7 @@ class Fizzy::Commands::UploadTest < Fizzy::TestCase
 
   def test_upload_file_creates_direct_upload
     # Step 1: Create direct upload
-    stub_request(:post, "https://app.fizzy.do/rails/active_storage/direct_uploads")
+    stub_request(:post, "https://app.fizzy.do/test_account/rails/active_storage/direct_uploads")
       .to_return(
         status: 200,
         body: {


### PR DESCRIPTION
## Summary

- Updates the direct upload endpoint to use the account-scoped path required by upstream fix [basecamp/fizzy#2079](https://github.com/basecamp/fizzy/pull/2079)
- Changes path from `/rails/active_storage/direct_uploads` to `/{account}/rails/active_storage/direct_uploads`
- The `fizzy upload file` command now works against the production API

Closes #5

## Test plan

- [x] All tests pass (103 runs, 206 assertions)
- [x] Manually verified `fizzy upload file` works against production API