### PR TITLE
Fix misleading --account option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ fizzy <resource> <action> [options]
 | Option | Environment Variable | Description |
 |--------|---------------------|-------------|
 | `--token` | `FIZZY_TOKEN` | API access token |
-| `--account` | `FIZZY_ACCOUNT` | Account ID |
+| `--account` | `FIZZY_ACCOUNT` | Account slug (from `fizzy identity show`) |
 | `--format` | | Output format: `json` (default), `text` |
 | `--quiet` | | Suppress non-essential output |
 | `--verbose` | | Show request/response details |

--- a/lib/fizzy/cli.rb
+++ b/lib/fizzy/cli.rb
@@ -5,7 +5,7 @@ module Fizzy
     end
 
     class_option :token, type: :string, desc: "API access token (or FIZZY_TOKEN env var)"
-    class_option :account, type: :string, desc: "Account ID (or FIZZY_ACCOUNT env var)"
+    class_option :account, type: :string, desc: "Account slug (or FIZZY_ACCOUNT env var)"
     class_option :api_url, type: :string, desc: "API base URL (default: https://app.fizzy.do)"
     class_option :format, type: :string, default: "json", desc: "Output format: json, text"
     class_option :quiet, type: :boolean, default: false, desc: "Suppress non-essential output"


### PR DESCRIPTION
## Summary
- Changed "Account ID" to "Account slug" in CLI help text and README
- The `--account` option expects the numeric slug (e.g., `6102600`) from `fizzy identity show`, not the UUID-style account ID

Users were getting 404 errors when using the account ID like `03f58rjxdx0ri1ihuqnqsib4n` instead of the slug from the identity response (`"slug": "/6102600"`).

## Test plan
- [x] Run `bundle exec rake test` - all 103 tests pass
- [x] Verified `fizzy board list --account=6102600` works across multiple accounts