### PR TITLE
Clarify account slug format in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ bundle install
 fizzy identity show
 ```
 
-4. Set your default account:
+4. Set your default account (use the numeric slug without the leading slash):
 
 ```bash
+# From identity show: "slug": "/897362094" → use 897362094
 export FIZZY_ACCOUNT=897362094
 ```
 


### PR DESCRIPTION
## Summary
- Added explicit guidance that the account slug should be used without the leading slash
- Shows the transformation: `"slug": "/897362094"` → use `897362094`

Users copying the slug directly from `fizzy identity show` were getting network errors because the leading slash caused malformed URLs.

## Test plan
- [x] `bundle exec rake test` - all 103 tests pass