### PR TITLE
Fix card list filters to use correct API parameter names

### DIFF
--- a/lib/fizzy/commands/card.rb
+++ b/lib/fizzy/commands/card.rb
@@ -3,18 +3,16 @@ module Fizzy
     class Card < Base
       desc "list", "List cards"
       option :board, type: :string, desc: "Filter by board ID"
-      option :column, type: :string, desc: "Filter by column ID"
       option :tag, type: :string, desc: "Filter by tag ID"
-      option :assignee, type: :string, desc: "Filter by assignee ID"
+      option :assignee, type: :string, desc: "Filter by assignee user ID"
       option :status, type: :string, desc: "Filter by status (published, closed, not_now)"
       option :page, type: :numeric, desc: "Page number"
       option :all, type: :boolean, default: false, desc: "Fetch all pages"
       def list
         params = {}
-        params[:board_id] = options[:board] if options[:board]
-        params[:column_id] = options[:column] if options[:column]
-        params[:tag_id] = options[:tag] if options[:tag]
-        params[:assignee_id] = options[:assignee] if options[:assignee]
+        params["board_ids[]"] = options[:board] if options[:board]
+        params["tag_ids[]"] = options[:tag] if options[:tag]
+        params["assignee_ids[]"] = options[:assignee] if options[:assignee]
         params[:status] = options[:status] if options[:status]
         params[:page] = options[:page] if options[:page]
 

--- a/test/fizzy/commands/card_test.rb
+++ b/test/fizzy/commands/card_test.rb
@@ -37,7 +37,7 @@ class Fizzy::Commands::CardTest < Fizzy::TestCase
 
   def test_list_with_filters
     stub_request(:get, "https://app.fizzy.do/test_account/cards")
-      .with(query: { "board_id" => "10", "status" => "published" })
+      .with(query: { "board_ids[]" => "10", "status" => "published" })
       .to_return(
         status: 200,
         body: '[{"id": "1", "title": "Filtered Card"}]',


### PR DESCRIPTION
## Summary
- Fixed `board_id` → `board_ids[]`
- Fixed `tag_id` → `tag_ids[]`  
- Fixed `assignee_id` → `assignee_ids[]`
- Removed `--column` filter (not supported by API)

The Fizzy API expects plural array params but the CLI was sending singular params, which the API silently ignored - causing all filter options to return unfiltered results.

## Test plan
- [x] `bundle exec rake test` - all 103 tests pass
- [x] Real API test: `fizzy card list --board=<id>` returns only cards from that board
- [x] Real API test: `fizzy card list --tag=<id>` returns only cards with that tag
- [x] Real API test: `fizzy card list --assignee=<id>` returns only assigned cards
- [x] Real API test: Combined filters work correctly