### PR TITLE
Add created_at option for cards and comments

### DIFF
--- a/lib/fizzy/commands/card.rb
+++ b/lib/fizzy/commands/card.rb
@@ -3,18 +3,16 @@ module Fizzy
     class Card < Base
       desc "list", "List cards"
       option :board, type: :string, desc: "Filter by board ID"
-      option :column, type: :string, desc: "Filter by column ID"
       option :tag, type: :string, desc: "Filter by tag ID"
-      option :assignee, type: :string, desc: "Filter by assignee ID"
+      option :assignee, type: :string, desc: "Filter by assignee user ID"
       option :status, type: :string, desc: "Filter by status (published, closed, not_now)"
       option :page, type: :numeric, desc: "Page number"
       option :all, type: :boolean, default: false, desc: "Fetch all pages"
       def list
         params = {}
-        params[:board_id] = options[:board] if options[:board]
-        params[:column_id] = options[:column] if options[:column]
-        params[:tag_id] = options[:tag] if options[:tag]
-        params[:assignee_id] = options[:assignee] if options[:assignee]
+        params["board_ids[]"] = options[:board] if options[:board]
+        params["tag_ids[]"] = options[:tag] if options[:tag]
+        params["assignee_ids[]"] = options[:assignee] if options[:assignee]
         params[:status] = options[:status] if options[:status]
         params[:page] = options[:page] if options[:page]
 
@@ -44,6 +42,7 @@ module Fizzy
       option :status, type: :string, desc: "Card status"
       option :tag_ids, type: :string, desc: "Comma-separated tag IDs"
       option :image, type: :string, desc: "Path to header image file"
+      option :created_at, type: :string, desc: "Custom creation timestamp (ISO 8601)"
       def create
         card_params = {
           title: options[:title]
@@ -56,6 +55,7 @@ module Fizzy
         end
 
         card_params[:status] = options[:status] if options[:status]
+        card_params[:created_at] = options[:created_at] if options[:created_at]
 
         if options[:tag_ids]
           card_params[:tag_ids] = options[:tag_ids].split(",").map(&:strip)
@@ -82,10 +82,12 @@ module Fizzy
       option :status, type: :string, desc: "Card status"
       option :tag_ids, type: :string, desc: "Comma-separated tag IDs"
       option :image, type: :string, desc: "Path to header image file"
+      option :created_at, type: :string, desc: "Custom creation timestamp (ISO 8601)"
       def update(number)
         card_params = {}
         card_params[:title] = options[:title] if options.key?(:title)
         card_params[:status] = options[:status] if options.key?(:status)
+        card_params[:created_at] = options[:created_at] if options[:created_at]
 
         if options[:description_file]
           card_params[:description] = File.read(options[:description_file])

--- a/lib/fizzy/commands/comment.rb
+++ b/lib/fizzy/commands/comment.rb
@@ -32,6 +32,7 @@ module Fizzy
       option :card, required: true, type: :string, desc: "Card number"
       option :body, type: :string, desc: "Comment body (supports rich text)"
       option :body_file, type: :string, desc: "Read body from file"
+      option :created_at, type: :string, desc: "Custom creation timestamp (ISO 8601)"
       def create
         comment_params = {}
 
@@ -43,6 +44,8 @@ module Fizzy
           raise Fizzy::ValidationError, "Either --body or --body-file is required"
         end
 
+        comment_params[:created_at] = options[:created_at] if options[:created_at]
+
         result = client.post(client.account_path("/cards/#{options[:card]}/comments"), { comment: comment_params })
         output(result)
       rescue Fizzy::Error => e
@@ -53,6 +56,7 @@ module Fizzy
       option :card, required: true, type: :string, desc: "Card number"
       option :body, type: :string, desc: "Comment body (supports rich text)"
       option :body_file, type: :string, desc: "Read body from file"
+      option :created_at, type: :string, desc: "Custom creation timestamp (ISO 8601)"
       def update(id)
         comment_params = {}
 
@@ -61,6 +65,8 @@ module Fizzy
         elsif options[:body]
           comment_params[:body] = options[:body]
         end
+
+        comment_params[:created_at] = options[:created_at] if options[:created_at]
 
         result = client.put(client.account_path("/cards/#{options[:card]}/comments/#{id}"), { comment: comment_params })
         output(result)

--- a/test/fizzy/commands/card_test.rb
+++ b/test/fizzy/commands/card_test.rb
@@ -37,7 +37,7 @@ class Fizzy::Commands::CardTest < Fizzy::TestCase
 
   def test_list_with_filters
     stub_request(:get, "https://app.fizzy.do/test_account/cards")
-      .with(query: { "board_id" => "10", "status" => "published" })
+      .with(query: { "board_ids[]" => "10", "status" => "published" })
       .to_return(
         status: 200,
         body: '[{"id": "1", "title": "Filtered Card"}]',
@@ -131,6 +131,26 @@ class Fizzy::Commands::CardTest < Fizzy::TestCase
     assert result["success"]
   end
 
+  def test_create_with_created_at
+    stub_request(:post, "https://app.fizzy.do/test_account/boards/5/cards")
+      .with(
+        body: { card: { title: "Card", created_at: "2024-01-15T10:30:00Z" } }.to_json
+      )
+      .to_return(
+        status: 201,
+        body: '{"id": "203", "title": "Card", "created_at": "2024-01-15T10:30:00Z"}',
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    output = capture_output do
+      Fizzy::Commands::Card.new([], { board: "5", title: "Card", created_at: "2024-01-15T10:30:00Z" }).invoke(:create, [])
+    end
+
+    result = JSON.parse(output)
+    assert result["success"]
+    assert_equal "2024-01-15T10:30:00Z", result["data"]["created_at"]
+  end
+
   def test_update_card
     stub_request(:put, "https://app.fizzy.do/test_account/cards/42")
       .with(
@@ -149,6 +169,26 @@ class Fizzy::Commands::CardTest < Fizzy::TestCase
     result = JSON.parse(output)
     assert result["success"]
     assert_equal "Updated Title", result["data"]["title"]
+  end
+
+  def test_update_card_with_created_at
+    stub_request(:put, "https://app.fizzy.do/test_account/cards/42")
+      .with(
+        body: { card: { created_at: "2024-01-15T10:30:00Z" } }.to_json
+      )
+      .to_return(
+        status: 200,
+        body: '{"id": "100", "number": 42, "created_at": "2024-01-15T10:30:00Z"}',
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    output = capture_output do
+      Fizzy::Commands::Card.new([], { created_at: "2024-01-15T10:30:00Z" }).invoke(:update, ["42"])
+    end
+
+    result = JSON.parse(output)
+    assert result["success"]
+    assert_equal "2024-01-15T10:30:00Z", result["data"]["created_at"]
   end
 
   def test_delete_card

--- a/test/fizzy/commands/comment_test.rb
+++ b/test/fizzy/commands/comment_test.rb
@@ -126,6 +126,27 @@ class Fizzy::Commands::CommentTest < Fizzy::TestCase
     assert_equal "VALIDATION_ERROR", result["error"]["code"]
   end
 
+  def test_create_comment_with_created_at
+    stub_request(:post, "https://app.fizzy.do/test_account/cards/42/comments")
+      .with(
+        body: { comment: { body: "New comment", created_at: "2024-01-15T10:30:00Z" } }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      .to_return(
+        status: 201,
+        body: '{"id": "c2", "body": {"plain_text": "New comment"}, "created_at": "2024-01-15T10:30:00Z"}',
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    output = capture_output do
+      Fizzy::Commands::Comment.new([], { card: "42", body: "New comment", created_at: "2024-01-15T10:30:00Z" }).invoke(:create, [])
+    end
+
+    result = JSON.parse(output)
+    assert result["success"]
+    assert_equal "2024-01-15T10:30:00Z", result["data"]["created_at"]
+  end
+
   def test_update_comment
     stub_request(:put, "https://app.fizzy.do/test_account/cards/42/comments/c1")
       .with(
@@ -143,6 +164,26 @@ class Fizzy::Commands::CommentTest < Fizzy::TestCase
 
     result = JSON.parse(output)
     assert result["success"]
+  end
+
+  def test_update_comment_with_created_at
+    stub_request(:put, "https://app.fizzy.do/test_account/cards/42/comments/c1")
+      .with(
+        body: { comment: { created_at: "2024-01-15T10:30:00Z" } }.to_json
+      )
+      .to_return(
+        status: 200,
+        body: '{"id": "c1", "created_at": "2024-01-15T10:30:00Z"}',
+        headers: { "Content-Type" => "application/json" }
+      )
+
+    output = capture_output do
+      Fizzy::Commands::Comment.new([], { card: "42", created_at: "2024-01-15T10:30:00Z" }).invoke(:update, ["c1"])
+    end
+
+    result = JSON.parse(output)
+    assert result["success"]
+    assert_equal "2024-01-15T10:30:00Z", result["data"]["created_at"]
   end
 
   def test_delete_comment


### PR DESCRIPTION
## Summary
- Added `--created_at` option to `card create` and `card update` commands
- Added `--created_at` option to `comment create` and `comment update` commands
- Fixed card list filters to use correct API parameter names (`board_ids[]`, `tag_ids[]`, `assignee_ids[]`)
- Removed unsupported `--column` filter from card list

The `created_at` option accepts ISO 8601 timestamps and allows backdating cards/comments for data imports.

## Test plan
- [x] `bundle exec rake test` - all 107 tests pass
- [x] Real API test: `fizzy card create --created_at="2020-06-15T10:30:00Z"` creates card with that timestamp
- [x] Real API test: `fizzy card update --created_at="2019-01-01T00:00:00Z"` updates card timestamp
- [x] Real API test: `fizzy comment create --created_at="2018-05-20T15:45:00Z"` creates comment with that timestamp
- [x] Real API test: `fizzy comment update --created_at="2017-01-01T00:00:00Z"` updates comment timestamp
- [x] Real API test: Board filter now works correctly with `board_ids[]` param