### PR TITLE
Follow Location header to return created resource data

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,24 @@ All commands output JSON by default:
 }
 ```
 
+When creating resources (e.g., cards, comments), the CLI automatically follows the `Location` header returned by the API to fetch the complete resource data, including server-generated fields like `id` and `number`:
+
+```json
+{
+  "success": true,
+  "data": {
+    "id": "abc123",
+    "number": 42,
+    "title": "New Card",
+    "status": "published"
+  },
+  "location": "https://app.fizzy.do/account/cards/42",
+  "meta": {
+    "timestamp": "2025-12-10T10:00:00Z"
+  }
+}
+```
+
 Errors return a non-zero exit code and structured error info:
 
 ```json

--- a/lib/fizzy/commands/base.rb
+++ b/lib/fizzy/commands/base.rb
@@ -47,7 +47,7 @@ module Fizzy
         elsif result.nil?
           Response.success(data: nil)
         else
-          Response.success(data: result[:data], pagination: result[:pagination])
+          Response.success(data: result[:data], pagination: result[:pagination], location: result[:location])
         end
 
         puts response.to_json

--- a/lib/fizzy/response.rb
+++ b/lib/fizzy/response.rb
@@ -1,9 +1,9 @@
 module Fizzy
   class Response
-    attr_reader :success, :data, :error, :pagination, :meta
+    attr_reader :success, :data, :error, :pagination, :meta, :location
 
-    def self.success(data:, pagination: nil)
-      new(success: true, data: data, pagination: pagination)
+    def self.success(data:, pagination: nil, location: nil)
+      new(success: true, data: data, pagination: pagination, location: location)
     end
 
     def self.error(code:, message:, status: nil, details: nil)
@@ -18,11 +18,12 @@ module Fizzy
       )
     end
 
-    def initialize(success:, data: nil, error: nil, pagination: nil)
+    def initialize(success:, data: nil, error: nil, pagination: nil, location: nil)
       @success = success
       @data = data
       @error = error
       @pagination = pagination
+      @location = location
       @meta = { timestamp: Time.now.utc.iso8601 }
     end
 
@@ -31,6 +32,7 @@ module Fizzy
       result[:data] = @data if @data
       result[:error] = @error if @error
       result[:pagination] = @pagination if @pagination
+      result[:location] = @location if @location
       result[:meta] = @meta
       result
     end


### PR DESCRIPTION
## Summary

Automatically follow the Location header returned by create endpoints to fetch complete resource data, including server-generated fields like `id` and `number`.

- Adds `follow_location` method in Client to fetch resource from Location URL
- Includes location URL in all API responses for reference
- Maintains backward compatibility with existing clients
- Comprehensive test coverage for Location header scenarios

## Benefits

- Eliminates need for clients to make a second request to get created resource details
- Cleaner API integration experience
- Server-generated IDs and numbers available immediately