### PR TITLE
docs: document API URL configuration for self-hosted setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,38 @@ fizzy identity show
 export FIZZY_ACCOUNT=897362094
 ```
 
+**Note:**
+If you're using a self-hosted domain instead of the default `https://app.fizzy.do`, specify it using one of these methods:
+
+**Option 1: Per-command flag (temporary)**
+```bash
+fizzy identity show --api-url=https://your_domain
+```
+
+**Option 2: Configuration file (permanent)**
+Add to your `~/.fizzy/config.yml`:
+
+```yml
+---
+token: your_token
+account: your_account_id
+api_url: https://your_domain
+```
+
+The config file method is recommended for self-hosted setups. Without specifying the API URL, you may encounter 302 redirect errors.
+```bash
+{
+  "success": false,
+  "error": {
+    "code": "ERROR",
+    "message": "Request failed: 302 Found"
+  },
+  "meta": {
+    "timestamp": "2025-12-13T07:55:38Z"
+  }
+}
+```
+
 ## Usage
 
 ```


### PR DESCRIPTION
### What

This PR adds a clarification to the README for users running Fizzy on a self-hosted domain.
By default, the CLI points to https://app.fizzy.do. When using a custom or local deployment, users must explicitly configure the API URL. Without doing so, CLI commands may fail with a 302 Found redirect error.

The README now documents two supported approaches:
- Per-command flag for temporary usage
- Configuration file (~/.fizzy/config.yml) for permanent self-hosted setups (recommended)

An example error response is also included to help users quickly identify the issue.

### Why

Several users running self-hosted instances may encounter unexpected redirect errors without realizing the CLI is still targeting the default hosted endpoint. This change improves onboarding and reduces confusion for self-hosted deployments.