### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ fizzy identity show --api-url=https://your_domain
 ```
 
 **Option 2: Configuration file (permanent)**
-Add to your `~/.fizzy/config.yml`:
+Add to your `~/.fizzy/config.yaml`:
 
 ```yml
 ---


### PR DESCRIPTION
Fizzy-cli writes a file called `fizzy.yaml` not `fizzy.yml`