### PR TITLE
Fix Release workflow checksum collisions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,17 @@ jobs:
           go build -trimpath -ldflags "-s -w -X main.version=${VERSION}" -o "dist/fizzy-${GOOS}-${GOARCH}${EXT}" ./cmd/fizzy
 
       - name: Checksums
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          EXT: ${{ matrix.ext }}
         run: |
           cd dist
-          sha256sum * > SHA256SUMS.txt
+          sha256sum "fizzy-${GOOS}-${GOARCH}${EXT}" > "SHA256SUMS-${GOOS}-${GOARCH}.txt"
 
       - name: Upload assets to release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            dist/*
-
+            dist/fizzy-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
+            dist/SHA256SUMS-${{ matrix.goos }}-${{ matrix.goarch }}.txt


### PR DESCRIPTION
## What went wrong
The Release workflow runs once per OS/arch. Each job generated a `dist/SHA256SUMS.txt` and uploaded `dist/*` to the GitHub Release.

That means multiple jobs try to upload (and overwrite) the same release asset name `SHA256SUMS.txt`. In your run, the Windows job hit a `404 Not Found` from the GitHub API endpoint used to update an existing release asset.

## Fix
Make checksum filenames unique per matrix job, and only upload the job’s binary + its checksum file.

This avoids asset-name collisions entirely.
