### PR TITLE
Card list: add --indexed-by (API-aligned)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ fizzy card list --column COLUMN_ID
 fizzy card list --column maybe
 fizzy card list --column done
 fizzy card list --tag TAG_ID
-fizzy card list --status published
+fizzy card list --indexed-by not_now
 fizzy card list --assignee USER_ID
 
 # Tip: if you set a default `board` in config (or `FIZZY_BOARD`), `fizzy card list` automatically filters to that board unless you pass `--board`.

--- a/e2e/tests/card_test.go
+++ b/e2e/tests/card_test.go
@@ -160,7 +160,7 @@ func TestCardListWithFilters(t *testing.T) {
 	})
 
 	t.Run("filters by status", func(t *testing.T) {
-		result := h.Run("card", "list", "--status", "published")
+		result := h.Run("card", "list", "--indexed-by", "not_now")
 
 		if result.ExitCode != harness.ExitSuccess {
 			t.Errorf("expected exit code %d, got %d", harness.ExitSuccess, result.ExitCode)

--- a/internal/commands/card_test.go
+++ b/internal/commands/card_test.go
@@ -52,19 +52,19 @@ func TestCardList(t *testing.T) {
 		defer ResetTestMode()
 
 		cardListBoard = "123"
-		cardListStatus = "published"
+		cardListIndexedBy = "closed"
 		RunTestCommand(func() {
 			cardListCmd.Run(cardListCmd, []string{})
 		})
 		cardListBoard = ""
-		cardListStatus = ""
+		cardListIndexedBy = ""
 
 		if result.ExitCode != 0 {
 			t.Errorf("expected exit code 0, got %d", result.ExitCode)
 		}
 		// Check that path contains filters
 		path := mock.GetWithPaginationCalls[0].Path
-		if path != "/cards.json?board_ids[]=123&status=published" {
+		if path != "/cards.json?board_ids[]=123&indexed_by=closed" {
 			t.Errorf("expected path with filters, got '%s'", path)
 		}
 	})


### PR DESCRIPTION
## Problem
Users expect card listing “status”/lane filters to match the official API (`indexed_by`). The CLI previously only exposed `--status` and sent `status=...`, which isn’t the documented way to filter Not Now / Done, etc.

## Fix
- Add `fizzy card list --indexed-by` and send `indexed_by=...` to the API.
- Keep `--status` as a deprecated alias for `--indexed-by` (so older docs/usages don’t immediately break).
- Update README + e2e/unit tests accordingly.

## Notes
`--column` continues to work for:
- pseudo lanes: `maybe` → `indexed_by=not_now`, `done` → `indexed_by=closed`
- triage/real column IDs: client-side filtering (requires `--all` or `--page`)
