### PR TITLE
Add AUR publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,3 +61,65 @@ jobs:
           files: |
             dist/fizzy-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
             dist/SHA256SUMS-${{ matrix.goos }}-${{ matrix.goarch }}.txt
+
+  aur-publish:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'release'
+    steps:
+      - name: Generate PKGBUILD
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+
+          # Download source tarball and calculate checksum
+          curl -sL "https://github.com/robzolkos/fizzy-cli/archive/v${VERSION}.tar.gz" -o source.tar.gz
+          SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
+
+          # Generate PKGBUILD
+          cat > PKGBUILD << 'EOF'
+          # Maintainer: Rob Zolkos <rob@zolkos.com>
+          pkgname=fizzy-cli
+          pkgver=VERSION_PLACEHOLDER
+          pkgrel=1
+          pkgdesc="CLI for managing Fizzy boards, cards, and tasks"
+          arch=('x86_64' 'aarch64')
+          url="https://github.com/robzolkos/fizzy-cli"
+          license=('MIT')
+          depends=('glibc')
+          makedepends=('go')
+          source=("$pkgname-$pkgver.tar.gz::https://github.com/robzolkos/fizzy-cli/archive/v$pkgver.tar.gz")
+          sha256sums=('SHA256_PLACEHOLDER')
+
+          build() {
+              cd "$pkgname-$pkgver"
+              export CGO_CPPFLAGS="${CPPFLAGS}"
+              export CGO_CFLAGS="${CFLAGS}"
+              export CGO_CXXFLAGS="${CXXFLAGS}"
+              export CGO_LDFLAGS="${LDFLAGS}"
+              export GOFLAGS="-buildmode=pie -trimpath -mod=readonly -modcacherw"
+              go build -ldflags "-s -w -X main.version=${pkgver}" -o fizzy ./cmd/fizzy
+          }
+
+          package() {
+              cd "$pkgname-$pkgver"
+              install -Dm755 fizzy "$pkgdir/usr/bin/fizzy"
+              install -Dm644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+          }
+          EOF
+
+          # Remove leading whitespace from PKGBUILD
+          sed -i 's/^          //' PKGBUILD
+
+          # Replace placeholders
+          sed -i "s/VERSION_PLACEHOLDER/$VERSION/" PKGBUILD
+          sed -i "s/SHA256_PLACEHOLDER/$SHA256/" PKGBUILD
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v3.0.1
+        with:
+          pkgname: fizzy-cli
+          pkgbuild: ./PKGBUILD
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"

--- a/README.md
+++ b/README.md
@@ -2,16 +2,21 @@
 
 A command-line interface for the [Fizzy](https://fizzy.do) API. See the official API docs at https://github.com/basecamp/fizzy/blob/main/docs/API.md.
 
-https://github.com/user-attachments/assets/86b91eae-7e8a-418c-a99e-3493ed7290cc
-
 ## Installation
 
-Download the latest release from [GitHub Releases](https://github.com/robzolkos/fizzy-cli/releases) and add it to your PATH.
+**Arch Linux (AUR)**
+```bash
+yay -S fizzy-cli
+```
 
 **With Go**
 ```bash
 go install github.com/robzolkos/fizzy-cli/cmd/fizzy@latest
 ```
+
+**From binary**
+
+Download the latest release from [GitHub Releases](https://github.com/robzolkos/fizzy-cli/releases) and add it to your PATH.
 
 **From source**
 ```bash
@@ -20,6 +25,58 @@ cd fizzy-cli
 go build -o fizzy ./cmd/fizzy
 ./fizzy --help
 ```
+
+## Configuration
+
+The CLI looks for configuration in multiple locations:
+
+### Global Configuration
+
+Global config is stored in one of these locations:
+- `~/.config/fizzy/config.yaml` (preferred)
+- `~/.fizzy/config.yaml`
+
+```yaml
+token: fizzy_abc123...
+account: 897362094
+api_url: https://app.fizzy.do
+board: 123456
+```
+
+### Local Project Configuration
+
+You can also create a `.fizzy.yaml` file in your project directory. The CLI walks up the directory tree to find it, so you can run commands from any subdirectory.
+
+```yaml
+# .fizzy.yaml - project-specific settings
+account: 123456789
+api_url: https://self-hosted.example.com
+board: 123456
+```
+
+Local config values merge with global config:
+- Values in local config override global config
+- Empty values in local config do not override global values
+- This allows you to keep your token in global config while overriding account per project
+
+**Example:** Global config has your token, local config specifies which account to use for this project:
+
+```yaml
+# ~/.config/fizzy/config.yaml (global)
+token: fizzy_abc123...
+
+# /path/to/project/.fizzy.yaml (local)
+account: 123456789
+```
+
+### Priority Order
+
+Configuration priority (highest to lowest):
+1. Command-line flags (`--token`, `--account`, `--api-url`)
+2. Environment variables (`FIZZY_TOKEN`, `FIZZY_ACCOUNT`, `FIZZY_API_URL`, `FIZZY_BOARD`)
+3. Local project config (`.fizzy.yaml` in current or parent directories)
+4. Global config (`~/.config/fizzy/config.yaml` or `~/.fizzy/config.yaml`)
+5. Defaults
 
 ## Quick Start
 
@@ -339,58 +396,6 @@ Errors return a non-zero exit code and structured error info:
 | 5 | Not found |
 | 6 | Validation error |
 | 7 | Network error |
-
-## Configuration
-
-The CLI looks for configuration in multiple locations:
-
-### Global Configuration
-
-Global config is stored in one of these locations:
-- `~/.config/fizzy/config.yaml` (preferred)
-- `~/.fizzy/config.yaml`
-
-```yaml
-token: fizzy_abc123...
-account: 897362094
-api_url: https://app.fizzy.do
-board: 123456
-```
-
-### Local Project Configuration
-
-You can also create a `.fizzy.yaml` file in your project directory. The CLI walks up the directory tree to find it, so you can run commands from any subdirectory.
-
-```yaml
-# .fizzy.yaml - project-specific settings
-account: 123456789
-api_url: https://self-hosted.example.com
-board: 123456
-```
-
-Local config values merge with global config:
-- Values in local config override global config
-- Empty values in local config do not override global values
-- This allows you to keep your token in global config while overriding account per project
-
-**Example:** Global config has your token, local config specifies which account to use for this project:
-
-```yaml
-# ~/.config/fizzy/config.yaml (global)
-token: fizzy_abc123...
-
-# /path/to/project/.fizzy.yaml (local)
-account: 123456789
-```
-
-### Priority Order
-
-Configuration priority (highest to lowest):
-1. Command-line flags (`--token`, `--account`, `--api-url`)
-2. Environment variables (`FIZZY_TOKEN`, `FIZZY_ACCOUNT`, `FIZZY_API_URL`, `FIZZY_BOARD`)
-3. Local project config (`.fizzy.yaml` in current or parent directories)
-4. Global config (`~/.config/fizzy/config.yaml` or `~/.fizzy/config.yaml`)
-5. Defaults
 
 ## Pagination
 


### PR DESCRIPTION
## Summary
- Adds AUR publishing job to the release workflow
- PKGBUILD is generated dynamically on each release (not stored in repo)
- Publishes to `fizzy-cli` package on AUR after binaries are built

## Required setup
Add these secrets to the repo:
- `AUR_USERNAME`
- `AUR_EMAIL`
- `AUR_SSH_PRIVATE_KEY`

## Initial AUR setup required
Before the first automated release, manually create the package on AUR:
```bash
git clone ssh://aur@aur.archlinux.org/fizzy-cli.git
cd fizzy-cli
# Add initial PKGBUILD and .SRCINFO
git push
```