### PR TITLE
Add .deb and .rpm package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,103 @@ jobs:
             dist/fizzy-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.ext }}
             dist/SHA256SUMS-${{ matrix.goos }}-${{ matrix.goarch }}.txt
 
+  build-packages:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            goarch: amd64
+            rpm_arch: x86_64
+          - arch: arm64
+            goarch: arm64
+            rpm_arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install packaging tools
+        run: sudo apt-get update && sudo apt-get install -y rpm
+
+      - name: Download binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          curl -sL "https://github.com/robzolkos/fizzy-cli/releases/download/v${VERSION}/fizzy-linux-${{ matrix.goarch }}" -o fizzy
+          chmod +x fizzy
+
+      - name: Build .deb package
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          PKG_ROOT="fizzy-cli_${VERSION}_${{ matrix.arch }}"
+
+          mkdir -p "${PKG_ROOT}/DEBIAN"
+          mkdir -p "${PKG_ROOT}/usr/bin"
+          mkdir -p "${PKG_ROOT}/usr/share/doc/fizzy-cli"
+
+          cp fizzy "${PKG_ROOT}/usr/bin/fizzy"
+          cp LICENSE "${PKG_ROOT}/usr/share/doc/fizzy-cli/copyright"
+
+          cat > "${PKG_ROOT}/DEBIAN/control" << EOF
+          Package: fizzy-cli
+          Version: ${VERSION}
+          Section: utils
+          Priority: optional
+          Architecture: ${{ matrix.arch }}
+          Maintainer: Rob Zolkos <rob@zolkos.com>
+          Description: CLI for managing Fizzy boards, cards, and tasks
+           A command-line interface for the Fizzy API.
+          Homepage: https://github.com/robzolkos/fizzy-cli
+          EOF
+
+          sed -i 's/^          //' "${PKG_ROOT}/DEBIAN/control"
+
+          dpkg-deb --build "${PKG_ROOT}"
+
+      - name: Build .rpm package
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+
+          mkdir -p rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+          mkdir -p rpmbuild/BUILDROOT/fizzy-cli-${VERSION}-1.${{ matrix.rpm_arch }}/usr/bin
+          mkdir -p rpmbuild/BUILDROOT/fizzy-cli-${VERSION}-1.${{ matrix.rpm_arch }}/usr/share/licenses/fizzy-cli
+
+          cp fizzy rpmbuild/BUILDROOT/fizzy-cli-${VERSION}-1.${{ matrix.rpm_arch }}/usr/bin/fizzy
+          cp LICENSE rpmbuild/BUILDROOT/fizzy-cli-${VERSION}-1.${{ matrix.rpm_arch }}/usr/share/licenses/fizzy-cli/LICENSE
+
+          cat > rpmbuild/SPECS/fizzy-cli.spec << EOF
+          Name:           fizzy-cli
+          Version:        ${VERSION}
+          Release:        1
+          Summary:        CLI for managing Fizzy boards, cards, and tasks
+          License:        MIT
+          URL:            https://github.com/robzolkos/fizzy-cli
+
+          %description
+          A command-line interface for the Fizzy API.
+
+          %files
+          %license /usr/share/licenses/fizzy-cli/LICENSE
+          /usr/bin/fizzy
+          EOF
+
+          rpmbuild --define "_topdir $(pwd)/rpmbuild" \
+                   --define "_rpmdir $(pwd)/rpmbuild/RPMS" \
+                   --target ${{ matrix.rpm_arch }} \
+                   -bb rpmbuild/SPECS/fizzy-cli.spec
+
+          cp rpmbuild/RPMS/${{ matrix.rpm_arch }}/*.rpm .
+
+      - name: Upload packages to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            fizzy-cli_*_${{ matrix.arch }}.deb
+            fizzy-cli-*.rpm
+
   aur-publish:
     runs-on: ubuntu-latest
     needs: build

--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ yay -S fizzy-cli
 brew install robzolkos/fizzy-cli/fizzy-cli
 ```
 
+**Debian/Ubuntu**
+```bash
+# Download the .deb for your architecture (amd64 or arm64)
+curl -LO https://github.com/robzolkos/fizzy-cli/releases/latest/download/fizzy-cli_VERSION_amd64.deb
+sudo dpkg -i fizzy-cli_VERSION_amd64.deb
+```
+
+**Fedora/RHEL**
+```bash
+# Download the .rpm for your architecture (x86_64 or aarch64)
+curl -LO https://github.com/robzolkos/fizzy-cli/releases/latest/download/fizzy-cli-VERSION-1.x86_64.rpm
+sudo rpm -i fizzy-cli-VERSION-1.x86_64.rpm
+```
+
+**Windows**
+
+Download `fizzy-windows-amd64.exe` from [GitHub Releases](https://github.com/robzolkos/fizzy-cli/releases), rename it to `fizzy.exe`, and add it to your PATH.
+
 **With Go**
 ```bash
 go install github.com/robzolkos/fizzy-cli/cmd/fizzy@latest
@@ -21,7 +39,7 @@ go install github.com/robzolkos/fizzy-cli/cmd/fizzy@latest
 
 **From binary**
 
-Download the latest release from [GitHub Releases](https://github.com/robzolkos/fizzy-cli/releases) and add it to your PATH.
+Download the latest release for your platform from [GitHub Releases](https://github.com/robzolkos/fizzy-cli/releases) and add it to your PATH.
 
 **From source**
 ```bash


### PR DESCRIPTION
## Summary
- Adds `build-packages` job to create `.deb` and `.rpm` packages for each release
- Packages built for both amd64/x86_64 and arm64/aarch64 architectures
- Updates README with installation instructions for Debian/Ubuntu, Fedora/RHEL, and Windows

## Release assets added
- `fizzy-cli_VERSION_amd64.deb`
- `fizzy-cli_VERSION_arm64.deb`
- `fizzy-cli-VERSION-1.x86_64.rpm`
- `fizzy-cli-VERSION-1.aarch64.rpm`

## Test plan
- [ ] Merge PR
- [ ] Create a new release
- [ ] Verify .deb and .rpm packages appear in release assets
- [ ] Test installing on Debian/Ubuntu with `sudo dpkg -i`
- [ ] Test installing on Fedora/RHEL with `sudo rpm -i`