### PR TITLE
Return attachable_sgid from upload for inline images

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -298,6 +298,9 @@ func (c *Client) UploadFile(filePath string) (*APIResponse, error) {
 		return nil, errors.NewError("Missing signed_id in response")
 	}
 
+	// Get attachable_sgid for use in action-text-attachment
+	attachableSGID, _ := blobData["attachable_sgid"].(string)
+
 	// Step 2: Upload file to the direct upload URL
 	uploadReq, err := http.NewRequest("PUT", uploadURL, bytes.NewReader(fileContent))
 	if err != nil {
@@ -322,12 +325,17 @@ func (c *Client) UploadFile(filePath string) (*APIResponse, error) {
 		return nil, errors.NewError(fmt.Sprintf("Upload failed: %d %s", uploadResp.StatusCode, string(body)))
 	}
 
-	// Return the signed_id
+	// Return the signed_id and attachable_sgid
+	responseData := map[string]interface{}{
+		"signed_id": signedID,
+	}
+	if attachableSGID != "" {
+		responseData["attachable_sgid"] = attachableSGID
+	}
+
 	return &APIResponse{
 		StatusCode: 200,
-		Data: map[string]interface{}{
-			"signed_id": signedID,
-		},
+		Data:       responseData,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Fix inline images in card descriptions showing as broken
- Upload command now returns both `signed_id` and `attachable_sgid`
- Updated README with correct usage documentation

## Problem
When uploading a file and using the returned ID in an `<action-text-attachment>` tag, inline images appeared broken (showing a checkbox with X). This was because the CLI only returned `signed_id`, but ActionText attachments require `attachable_sgid` which includes the proper GID format.

## Solution
The upload response now includes both IDs:
```json
{
  "signed_id": "...",        // For --image flag (header images)
  "attachable_sgid": "..."   // For <action-text-attachment> (inline images)
}
```

## Test plan
- [x] Upload a file and verify both `signed_id` and `attachable_sgid` are returned
- [x] Create a card with `--image` using `signed_id` - header image should display
- [x] Create a card with inline `<action-text-attachment sgid="...">` using `attachable_sgid` - inline image should display
- [x] Verify existing tests pass