### PR TITLE
Add card image removal and goldness endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ fizzy card tag 42 --tag "bug"
 # Watch/unwatch
 fizzy card watch 42
 fizzy card unwatch 42
+
+# Remove card header image
+fizzy card image-remove 42
+
+# Mark/unmark card as golden
+fizzy card golden 42
+fizzy card ungolden 42
 ```
 
 ### Card Attachments

--- a/internal/commands/card.go
+++ b/internal/commands/card.go
@@ -608,6 +608,78 @@ var cardUnwatchCmd = &cobra.Command{
 	},
 }
 
+var cardImageRemoveCmd = &cobra.Command{
+	Use:   "image-remove CARD_NUMBER",
+	Short: "Remove card header image",
+	Long:  "Removes the header image from a card.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		client := getClient()
+		resp, err := client.Delete("/cards/" + args[0] + "/image.json")
+		if err != nil {
+			exitWithError(err)
+		}
+
+		if resp.Data != nil {
+			printSuccess(resp.Data)
+		} else {
+			printSuccess(map[string]interface{}{})
+		}
+	},
+}
+
+var cardGoldenCmd = &cobra.Command{
+	Use:   "golden CARD_NUMBER",
+	Short: "Mark card as golden",
+	Long:  "Marks a card as golden (starred/important).",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		client := getClient()
+		resp, err := client.Post("/cards/"+args[0]+"/goldness.json", nil)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		if resp.Data != nil {
+			printSuccess(resp.Data)
+		} else {
+			printSuccess(map[string]interface{}{})
+		}
+	},
+}
+
+var cardUngoldenCmd = &cobra.Command{
+	Use:   "ungolden CARD_NUMBER",
+	Short: "Remove golden status from card",
+	Long:  "Removes the golden (starred/important) status from a card.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		client := getClient()
+		resp, err := client.Delete("/cards/" + args[0] + "/goldness.json")
+		if err != nil {
+			exitWithError(err)
+		}
+
+		if resp.Data != nil {
+			printSuccess(resp.Data)
+		} else {
+			printSuccess(map[string]interface{}{})
+		}
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(cardCmd)
 
@@ -670,4 +742,11 @@ func init() {
 	// Watch/Unwatch
 	cardCmd.AddCommand(cardWatchCmd)
 	cardCmd.AddCommand(cardUnwatchCmd)
+
+	// Image removal
+	cardCmd.AddCommand(cardImageRemoveCmd)
+
+	// Golden
+	cardCmd.AddCommand(cardGoldenCmd)
+	cardCmd.AddCommand(cardUngoldenCmd)
 }

--- a/internal/commands/card_test.go
+++ b/internal/commands/card_test.go
@@ -815,3 +815,183 @@ func TestCardUnwatch(t *testing.T) {
 		}
 	})
 }
+
+func TestCardImageRemove(t *testing.T) {
+	t.Run("removes card header image", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardImageRemoveCmd.Run(cardImageRemoveCmd, []string{"42"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.DeleteCalls) != 1 {
+			t.Fatalf("expected 1 delete call, got %d", len(mock.DeleteCalls))
+		}
+		if mock.DeleteCalls[0].Path != "/cards/42/image.json" {
+			t.Errorf("expected path '/cards/42/image.json', got '%s'", mock.DeleteCalls[0].Path)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardImageRemoveCmd.Run(cardImageRemoveCmd, []string{"42"})
+		})
+
+		if result.ExitCode != errors.ExitAuthFailure {
+			t.Errorf("expected exit code %d, got %d", errors.ExitAuthFailure, result.ExitCode)
+		}
+	})
+
+	t.Run("handles not found error", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteError = errors.NewNotFoundError("Card not found")
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardImageRemoveCmd.Run(cardImageRemoveCmd, []string{"999"})
+		})
+
+		if result.ExitCode != errors.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d", errors.ExitNotFound, result.ExitCode)
+		}
+	})
+}
+
+func TestCardGolden(t *testing.T) {
+	t.Run("marks card as golden", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PostResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardGoldenCmd.Run(cardGoldenCmd, []string{"42"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.PostCalls) != 1 {
+			t.Fatalf("expected 1 post call, got %d", len(mock.PostCalls))
+		}
+		if mock.PostCalls[0].Path != "/cards/42/goldness.json" {
+			t.Errorf("expected path '/cards/42/goldness.json', got '%s'", mock.PostCalls[0].Path)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardGoldenCmd.Run(cardGoldenCmd, []string{"42"})
+		})
+
+		if result.ExitCode != errors.ExitAuthFailure {
+			t.Errorf("expected exit code %d, got %d", errors.ExitAuthFailure, result.ExitCode)
+		}
+	})
+
+	t.Run("handles not found error", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PostError = errors.NewNotFoundError("Card not found")
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardGoldenCmd.Run(cardGoldenCmd, []string{"999"})
+		})
+
+		if result.ExitCode != errors.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d", errors.ExitNotFound, result.ExitCode)
+		}
+	})
+}
+
+func TestCardUngolden(t *testing.T) {
+	t.Run("removes golden status from card", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardUngoldenCmd.Run(cardUngoldenCmd, []string{"42"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.DeleteCalls) != 1 {
+			t.Fatalf("expected 1 delete call, got %d", len(mock.DeleteCalls))
+		}
+		if mock.DeleteCalls[0].Path != "/cards/42/goldness.json" {
+			t.Errorf("expected path '/cards/42/goldness.json', got '%s'", mock.DeleteCalls[0].Path)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardUngoldenCmd.Run(cardUngoldenCmd, []string{"42"})
+		})
+
+		if result.ExitCode != errors.ExitAuthFailure {
+			t.Errorf("expected exit code %d, got %d", errors.ExitAuthFailure, result.ExitCode)
+		}
+	})
+
+	t.Run("handles not found error", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteError = errors.NewNotFoundError("Card not found")
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			cardUngoldenCmd.Run(cardUngoldenCmd, []string{"999"})
+		})
+
+		if result.ExitCode != errors.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d", errors.ExitNotFound, result.ExitCode)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds `card image-remove` command to remove header image from a card (DELETE /cards/:number/image.json)
- Adds `card golden` command to mark a card as golden (POST /cards/:number/goldness.json)
- Adds `card ungolden` command to remove golden status (DELETE /cards/:number/goldness.json)

Closes #34

## Test plan
- [x] Unit tests added for all 3 new commands (9 tests total)
- [x] E2E tests added and passing against live API (5 tests total)
- [x] All existing tests pass
- [x] README documentation updated