### PR TITLE
Default to compact JSON output, add --pretty flag

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -17,6 +17,7 @@ var (
 	cfgAccount string
 	cfgAPIURL  string
 	cfgVerbose bool
+	cfgPretty  bool
 
 	// Loaded config
 	cfg *config.Config
@@ -50,6 +51,9 @@ Use fizzy to manage boards, cards, comments, and more from your terminal.`,
 		if cfgAPIURL != "" {
 			cfg.APIURL = cfgAPIURL
 		}
+
+		// Set response formatting
+		response.SetPrettyPrint(cfgPretty)
 	},
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -78,6 +82,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&cfgAccount, "account", "", "Account slug")
 	rootCmd.PersistentFlags().StringVar(&cfgAPIURL, "api-url", "", "API base URL")
 	rootCmd.PersistentFlags().BoolVar(&cfgVerbose, "verbose", false, "Show request/response details")
+	rootCmd.PersistentFlags().BoolVar(&cfgPretty, "pretty", false, "Pretty-print JSON output with indentation")
 }
 
 // getClient returns an API client configured from global settings.

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -11,6 +11,14 @@ import (
 	"github.com/robzolkos/fizzy-cli/internal/errors"
 )
 
+// prettyPrint controls whether JSON output is indented.
+var prettyPrint bool
+
+// SetPrettyPrint enables or disables pretty-printed JSON output.
+func SetPrettyPrint(enabled bool) {
+	prettyPrint = enabled
+}
+
 // Response represents the JSON response envelope.
 type Response struct {
 	Success    bool                   `json:"success"`
@@ -104,7 +112,9 @@ func createMeta() map[string]interface{} {
 func (r *Response) Print() {
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
-	encoder.SetIndent("", "  ")
+	if prettyPrint {
+		encoder.SetIndent("", "  ")
+	}
 	encoder.SetEscapeHTML(false)
 	if err := encoder.Encode(r); err != nil {
 		fmt.Fprintf(os.Stderr, "Error marshaling response: %v\n", err)


### PR DESCRIPTION
## Summary
- Makes JSON output single-line (compact) by default for better token efficiency when used by LLM tools
- Adds `--pretty` global flag to restore indented output for human readability

## Test plan
- [x] `fizzy card list` outputs compact JSON (single line)
- [x] `fizzy card list --pretty` outputs indented JSON
- [x] Unit tests pass