### PR TITLE
Add Codex skill install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ fizzy migrate board BOARD_ID --from SOURCE_ACCOUNT --to TARGET_ACCOUNT --include
 
 ### Skill Installation
 
-Install the Fizzy skill file for use with AI coding assistants like Claude Code or OpenCode.
+Install the Fizzy skill file for use with AI coding assistants like Codex, Claude Code, or OpenCode.
 
 ```bash
 fizzy skill
@@ -436,6 +436,7 @@ This interactive command lets you choose where to install the SKILL.md file:
 | Claude Code (Project) | `.claude/skills/fizzy/SKILL.md` |
 | OpenCode (Global) | `~/.config/opencode/skill/fizzy/SKILL.md` |
 | OpenCode (Project) | `.opencode/skill/fizzy/SKILL.md` |
+| Codex (Global) | `~/.codex/skills/fizzy/SKILL.md` (or `$CODEX_HOME/skills/fizzy/SKILL.md`) |
 | Other | Custom path of your choice |
 
 The skill file enables AI assistants to understand and use Fizzy CLI commands effectively.

--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -43,12 +43,17 @@ var skillLocations = []SkillLocation{
 		Path:        ".opencode/skill/fizzy/SKILL.md",
 		Description: "Available only in this project",
 	},
+	{
+		Name:        "Codex (Global)",
+		Path:        codexGlobalSkillPath(),
+		Description: "Available in all Codex projects",
+	},
 }
 
 var skillCmd = &cobra.Command{
 	Use:   "skill",
 	Short: "Install Fizzy skill file",
-	Long:  "Install the Fizzy SKILL.md file for use with Claude Code or OpenCode.",
+	Long:  "Install the Fizzy SKILL.md file for use with Codex, Claude Code, or OpenCode.",
 	Run:   runSkill,
 }
 
@@ -170,6 +175,14 @@ func normalizeSkillPath(path string) string {
 
 	// Path is a directory, add fizzy/SKILL.md
 	return filepath.Join(path, "fizzy", skillFilename)
+}
+
+func codexGlobalSkillPath() string {
+	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
+	if codexHome == "" {
+		return "~/.codex/skills/fizzy/SKILL.md"
+	}
+	return filepath.Join(codexHome, "skills", "fizzy", skillFilename)
 }
 
 // expandPath expands ~ to home directory (works on both Unix and Windows)


### PR DESCRIPTION
## Summary
- add Codex global install location to `fizzy skill`
- respect `CODEX_HOME` for the Codex skill path
- document Codex install path in README

## Testing
- `make build`
- Installed it on my machine and it works.
