### PR TITLE
Fix empty api_url from setup

### DIFF
--- a/internal/commands/setup.go
+++ b/internal/commands/setup.go
@@ -235,11 +235,7 @@ func runSetup(cmd *cobra.Command, args []string) {
 		Token:   token,
 		Account: selectedAccountSlug,
 		Board:   selectedBoardID,
-	}
-
-	// Only set API URL if not default
-	if apiURL != config.DefaultAPIURL {
-		newConfig.APIURL = apiURL
+		APIURL:  apiURL,
 	}
 
 	if saveGlobal {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -152,6 +153,7 @@ func Load() *Config {
 		cfg.Board = board
 	}
 
+	ensureAPIURL(cfg)
 	return cfg
 }
 
@@ -167,7 +169,17 @@ func LoadGlobal() *Config {
 			break
 		}
 	}
+	ensureAPIURL(cfg)
 	return cfg
+}
+
+func ensureAPIURL(cfg *Config) {
+	if cfg == nil {
+		return
+	}
+	if strings.TrimSpace(cfg.APIURL) == "" {
+		cfg.APIURL = DefaultAPIURL
+	}
 }
 
 // ConfigPath returns the path to the global config file (creating directory if needed).

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -113,6 +113,35 @@ board: file-board-345
 	}
 }
 
+func TestLoad_EmptyAPIURLDefaults(t *testing.T) {
+	// Clear environment variables
+	os.Unsetenv("FIZZY_TOKEN")
+	os.Unsetenv("FIZZY_ACCOUNT")
+	os.Unsetenv("FIZZY_API_URL")
+
+	// Create temp home directory with config file
+	origHome := os.Getenv("HOME")
+	tempDir := t.TempDir()
+	os.Setenv("HOME", tempDir)
+	defer os.Setenv("HOME", origHome)
+
+	configDir := filepath.Join(tempDir, ".fizzy")
+	os.MkdirAll(configDir, 0700)
+	configFile := filepath.Join(configDir, "config.yaml")
+
+	configContent := `token: file-token
+account: file-account
+api_url: ""
+`
+	os.WriteFile(configFile, []byte(configContent), 0600)
+
+	cfg := Load()
+
+	if cfg.APIURL != DefaultAPIURL {
+		t.Errorf("expected APIURL '%s', got '%s'", DefaultAPIURL, cfg.APIURL)
+	}
+}
+
 func TestLoad_EnvOverridesFile(t *testing.T) {
 	// Create temp home directory with config file
 	origHome := os.Getenv("HOME")


### PR DESCRIPTION
## Summary
- fix a setup/config edge case where `api_url: ""` persisted in config could override the default and produce invalid request URLs
- make config loading resilient by normalizing empty `api_url` to the hosted default
- persist a concrete API URL during setup for hosted installs to avoid writing empty values

## Root Cause
When a user selects the hosted option in `fizzy setup`, we did not set `APIURL` on the config struct. YAML serialization still wrote `api_url: ""`. On subsequent runs, `config.Load()` would initialize `APIURL` to the default, but `yaml.Unmarshal` would overwrite it with the empty string. That led to requests like `"/ACCOUNT/cards.json"` and the error `unsupported protocol scheme ""`.

## Fix
- `config.Load()` / `LoadGlobal()` now treat empty `api_url` as "unset" and reapply `DefaultAPIURL`.
- `setup` always writes the chosen URL (hosted => `https://app.fizzy.do`) so the config file never stores an empty URL.

## Testing
- `go test ./internal/...`
