### PR TITLE
Add search command and extended card list filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,15 @@ fizzy card list --sort newest    # oldest cards first (by created_at)
 fizzy card list --sort oldest    # newest cards first (by created_at)
 fizzy card list --sort latest    # most recently updated (default)
 
+# Additional filters
+fizzy card list --search "bug"           # Search by text
+fizzy card list --sort newest            # Sort: newest, oldest, latest (default)
+fizzy card list --creator USER_ID        # Filter by creator
+fizzy card list --closer USER_ID         # Filter by who closed
+fizzy card list --unassigned             # Only unassigned cards
+fizzy card list --created thisweek       # Created: today, yesterday, thisweek, lastweek, thismonth, lastmonth
+fizzy card list --closed thisweek        # Closed: today, yesterday, thisweek, lastweek, thismonth, lastmonth
+
 # Tip: if you set a default `board` in config (or `FIZZY_BOARD`), `fizzy card list` automatically filters to that board unless you pass `--board`.
 
 # Show a card
@@ -325,6 +334,21 @@ fizzy user show USER_ID
 
 ```bash
 fizzy tag list
+```
+
+### Search
+
+```bash
+# Search cards by text
+fizzy search "bug"
+fizzy search "login error"              # Multiple terms (AND)
+
+# Combine with filters
+fizzy search "bug" --board BOARD_ID
+fizzy search "bug" --tag TAG_ID
+fizzy search "bug" --assignee USER_ID
+fizzy search "bug" --indexed-by closed  # Include closed cards
+fizzy search "bug" --sort newest        # Sort by created_at desc
 ```
 
 ### Notifications

--- a/internal/commands/card.go
+++ b/internal/commands/card.go
@@ -21,7 +21,13 @@ var cardListColumn string
 var cardListTag string
 var cardListIndexedBy string
 var cardListAssignee string
+var cardListSearch string
 var cardListSort string
+var cardListCreator string
+var cardListCloser string
+var cardListUnassigned bool
+var cardListCreated string
+var cardListClosed string
 var cardListPage int
 var cardListAll bool
 
@@ -88,8 +94,28 @@ var cardListCmd = &cobra.Command{
 		if cardListAssignee != "" {
 			params = append(params, "assignee_ids[]="+cardListAssignee)
 		}
+		if cardListSearch != "" {
+			for _, term := range strings.Fields(cardListSearch) {
+				params = append(params, "terms[]="+term)
+			}
+		}
 		if cardListSort != "" {
 			params = append(params, "sorted_by="+cardListSort)
+		}
+		if cardListCreator != "" {
+			params = append(params, "creator_ids[]="+cardListCreator)
+		}
+		if cardListCloser != "" {
+			params = append(params, "closer_ids[]="+cardListCloser)
+		}
+		if cardListUnassigned {
+			params = append(params, "assignment_status=unassigned")
+		}
+		if cardListCreated != "" {
+			params = append(params, "creation="+cardListCreated)
+		}
+		if cardListClosed != "" {
+			params = append(params, "closure="+cardListClosed)
 		}
 		if cardListPage > 0 {
 			params = append(params, "page="+strconv.Itoa(cardListPage))
@@ -695,7 +721,13 @@ func init() {
 	cardListCmd.Flags().StringVar(&cardListIndexedBy, "status", "", "Alias for --indexed-by")
 	_ = cardListCmd.Flags().MarkDeprecated("status", "use --indexed-by")
 	cardListCmd.Flags().StringVar(&cardListAssignee, "assignee", "", "Filter by assignee ID")
+	cardListCmd.Flags().StringVar(&cardListSearch, "search", "", "Search terms (space-separated for multiple)")
 	cardListCmd.Flags().StringVar(&cardListSort, "sort", "", "Sort order: newest, oldest, or latest (default)")
+	cardListCmd.Flags().StringVar(&cardListCreator, "creator", "", "Filter by creator user ID")
+	cardListCmd.Flags().StringVar(&cardListCloser, "closer", "", "Filter by closer user ID")
+	cardListCmd.Flags().BoolVar(&cardListUnassigned, "unassigned", false, "Only show unassigned cards")
+	cardListCmd.Flags().StringVar(&cardListCreated, "created", "", "Filter by creation time (today, yesterday, thisweek, lastweek, thismonth, lastmonth)")
+	cardListCmd.Flags().StringVar(&cardListClosed, "closed", "", "Filter by closure time (today, yesterday, thisweek, lastweek, thismonth, lastmonth)")
 	cardListCmd.Flags().IntVar(&cardListPage, "page", 0, "Page number")
 	cardListCmd.Flags().BoolVar(&cardListAll, "all", false, "Fetch all pages")
 	cardCmd.AddCommand(cardListCmd)

--- a/internal/commands/card_test.go
+++ b/internal/commands/card_test.go
@@ -193,6 +193,195 @@ func TestCardList(t *testing.T) {
 			t.Errorf("expected exit code %d, got %d", errors.ExitAuthFailure, result.ExitCode)
 		}
 	})
+
+	t.Run("applies search filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListSearch = "bug fix"
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListSearch = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&terms[]=fix" {
+			t.Errorf("expected path with search terms, got '%s'", path)
+		}
+	})
+
+	t.Run("applies sort filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListSort = "newest"
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListSort = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?sorted_by=newest" {
+			t.Errorf("expected path with sort, got '%s'", path)
+		}
+	})
+
+	t.Run("applies creator filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListCreator = "user-123"
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListCreator = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?creator_ids[]=user-123" {
+			t.Errorf("expected path with creator filter, got '%s'", path)
+		}
+	})
+
+	t.Run("applies unassigned filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListUnassigned = true
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListUnassigned = false
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?assignment_status=unassigned" {
+			t.Errorf("expected path with unassigned filter, got '%s'", path)
+		}
+	})
+
+	t.Run("applies created filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListCreated = "thisweek"
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListCreated = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?creation=thisweek" {
+			t.Errorf("expected path with created filter, got '%s'", path)
+		}
+	})
+
+	t.Run("applies closed filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListClosed = "lastmonth"
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListClosed = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?closure=lastmonth" {
+			t.Errorf("expected path with closed filter, got '%s'", path)
+		}
+	})
+
+	t.Run("combines multiple new filters", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		cardListBoard = "123"
+		cardListSearch = "bug"
+		cardListSort = "newest"
+		cardListUnassigned = true
+		RunTestCommand(func() {
+			cardListCmd.Run(cardListCmd, []string{})
+		})
+		cardListBoard = ""
+		cardListSearch = ""
+		cardListSort = ""
+		cardListUnassigned = false
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		expected := "/cards.json?board_ids[]=123&terms[]=bug&sorted_by=newest&assignment_status=unassigned"
+		if path != expected {
+			t.Errorf("expected path '%s', got '%s'", expected, path)
+		}
+	})
 }
 
 func TestCardShow(t *testing.T) {

--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -1,0 +1,86 @@
+package commands
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// Search flags
+var searchBoard string
+var searchTag string
+var searchAssignee string
+var searchIndexedBy string
+var searchSort string
+var searchPage int
+var searchAll bool
+
+var searchCmd = &cobra.Command{
+	Use:   "search QUERY",
+	Short: "Search cards",
+	Long:  "Searches cards by text. Multiple words are treated as separate terms (AND).",
+	Args:  cobra.MinimumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		query := strings.Join(args, " ")
+
+		client := getClient()
+		path := "/cards.json"
+
+		var params []string
+
+		// Add search terms
+		for _, term := range strings.Fields(query) {
+			params = append(params, "terms[]="+term)
+		}
+
+		// Add optional filters
+		boardID := defaultBoard(searchBoard)
+		if boardID != "" {
+			params = append(params, "board_ids[]="+boardID)
+		}
+		if searchTag != "" {
+			params = append(params, "tag_ids[]="+searchTag)
+		}
+		if searchAssignee != "" {
+			params = append(params, "assignee_ids[]="+searchAssignee)
+		}
+		if searchIndexedBy != "" {
+			params = append(params, "indexed_by="+searchIndexedBy)
+		}
+		if searchSort != "" {
+			params = append(params, "sorted_by="+searchSort)
+		}
+		if searchPage > 0 {
+			params = append(params, "page="+strconv.Itoa(searchPage))
+		}
+
+		if len(params) > 0 {
+			path += "?" + strings.Join(params, "&")
+		}
+
+		resp, err := client.GetWithPagination(path, searchAll)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		hasNext := resp.LinkNext != ""
+		printSuccessWithPagination(resp.Data, hasNext, resp.LinkNext)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(searchCmd)
+
+	searchCmd.Flags().StringVar(&searchBoard, "board", "", "Filter by board ID")
+	searchCmd.Flags().StringVar(&searchTag, "tag", "", "Filter by tag ID")
+	searchCmd.Flags().StringVar(&searchAssignee, "assignee", "", "Filter by assignee ID")
+	searchCmd.Flags().StringVar(&searchIndexedBy, "indexed-by", "", "Filter by status (all, closed, not_now, golden)")
+	searchCmd.Flags().StringVar(&searchSort, "sort", "", "Sort order: newest, oldest, or latest (default)")
+	searchCmd.Flags().IntVar(&searchPage, "page", 0, "Page number")
+	searchCmd.Flags().BoolVar(&searchAll, "all", false, "Fetch all pages")
+}

--- a/internal/commands/search_test.go
+++ b/internal/commands/search_test.go
@@ -1,0 +1,156 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/robzolkos/fizzy-cli/internal/client"
+	"github.com/robzolkos/fizzy-cli/internal/errors"
+)
+
+func TestSearch(t *testing.T) {
+	t.Run("searches cards with single term", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data: []interface{}{
+				map[string]interface{}{"id": "1", "title": "Bug fix"},
+			},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"bug"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if !result.Response.Success {
+			t.Error("expected success response")
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug" {
+			t.Errorf("expected path '/cards.json?terms[]=bug', got '%s'", path)
+		}
+	})
+
+	t.Run("searches cards with multiple terms", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"login error"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=login&terms[]=error" {
+			t.Errorf("expected path with multiple terms, got '%s'", path)
+		}
+	})
+
+	t.Run("combines search with board filter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		searchBoard = "123"
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"bug"})
+		})
+		searchBoard = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&board_ids[]=123" {
+			t.Errorf("expected path with board filter, got '%s'", path)
+		}
+	})
+
+	t.Run("applies sort parameter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		searchSort = "newest"
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"bug"})
+		})
+		searchSort = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&sorted_by=newest" {
+			t.Errorf("expected path with sort, got '%s'", path)
+		}
+	})
+
+	t.Run("applies indexed-by parameter", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		searchIndexedBy = "closed"
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"bug"})
+		})
+		searchIndexedBy = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		path := mock.GetWithPaginationCalls[0].Path
+		if path != "/cards.json?terms[]=bug&indexed_by=closed" {
+			t.Errorf("expected path with indexed_by, got '%s'", path)
+		}
+	})
+
+	t.Run("requires authentication", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			searchCmd.Run(searchCmd, []string{"bug"})
+		})
+
+		if result.ExitCode != errors.ExitAuthFailure {
+			t.Errorf("expected exit code %d, got %d", errors.ExitAuthFailure, result.ExitCode)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `fizzy search` command for quick text searches with basic filters
- Add new flags to `fizzy card list` for full API coverage

### `fizzy search` (new command)
```bash
fizzy search "bug"
fizzy search "login error"              # Multiple terms (AND)
fizzy search "bug" --board BOARD_ID
fizzy search "bug" --indexed-by closed  # Include closed cards
fizzy search "bug" --sort newest
```

### `fizzy card list` (new flags)
| Flag | API Parameter | Description |
|------|---------------|-------------|
| `--search` | `terms[]` | Search by text |
| `--sort` | `sorted_by` | newest, oldest, latest |
| `--creator` | `creator_ids[]` | Filter by creator |
| `--closer` | `closer_ids[]` | Filter by who closed |
| `--unassigned` | `assignment_status` | Only unassigned cards |
| `--created` | `creation` | today, yesterday, thisweek, etc. |
| `--closed` | `closure` | today, yesterday, thisweek, etc. |

## Test plan
- [x] Unit tests for `fizzy search` (6 tests)
- [x] Unit tests for new `card list` flags (7 tests)
- [x] Manual testing against live API
- [x] All 134 tests pass