### PR TITLE
Add card move command

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ fizzy card delete 42
 fizzy card close 42
 fizzy card reopen 42
 
+# Move to a different board
+fizzy card move 42 --to BOARD_ID
+fizzy card move 42 -t BOARD_ID
+
 # Move to "Not Now"
 fizzy card postpone 42
 


### PR DESCRIPTION
## Summary
- Adds `fizzy card move <card_number> --to <board_id>` command to move cards between boards
- Uses PATCH /cards/:num/board.json endpoint with board_id in request body
- Shows confirmation with card title after successful move

## Test plan
- [x] Unit tests added for move command (success, missing flag, not found error)
- [x] Manual testing: created card in Test Board, moved to Test Board 2, moved back
- [x] All existing unit tests pass