### PR TITLE
Add breadcrumbs to CLI responses for contextual next actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,30 @@ fizzy search "bug" | jq -r '.summary'
 
 The summary adapts to pagination flags (`--page N` or `--all`) and includes contextual details like unread counts for notifications.
 
+### Breadcrumbs
+
+Command responses include a `breadcrumbs` array with suggested next actions. This is designed for AI agents (and humans) to discover contextual workflows without needing to know the full CLI.
+
+```bash
+fizzy card show 42 | jq '.breadcrumbs'
+```
+
+```json
+[
+  {"action": "comment", "cmd": "fizzy comment create --card 42 --body \"text\"", "description": "Add comment"},
+  {"action": "triage", "cmd": "fizzy card column 42 --column <column_id>", "description": "Move to column"},
+  {"action": "close", "cmd": "fizzy card close 42", "description": "Close card"},
+  {"action": "assign", "cmd": "fizzy card assign 42 --user <user_id>", "description": "Assign user"}
+]
+```
+
+Each breadcrumb contains:
+- `action`: A short identifier for the action type
+- `cmd`: The complete CLI command to execute
+- `description`: Human-readable description
+
+Breadcrumbs are included by default in all responses. They are contextual - after creating a card you'll see suggestions to view, triage, or comment on it; after listing cards you'll see suggestions to show a specific card, create a new one, or search.
+
 When creating resources, the CLI automatically follows the `Location` header to fetch the complete resource data:
 
 ```json

--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"github.com/robzolkos/fizzy-cli/internal/config"
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -27,10 +28,17 @@ var authLoginCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(map[string]interface{}{
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("status", "fizzy auth status", "Check auth status"),
+			breadcrumb("identity", "fizzy identity show", "View identity"),
+			breadcrumb("boards", "fizzy board list", "List boards"),
+		}
+
+		printSuccessWithBreadcrumbs(map[string]interface{}{
 			"authenticated": true,
 			"message":       "Token saved to config file",
-		})
+		}, "", breadcrumbs)
 	},
 }
 
@@ -43,10 +51,15 @@ var authLogoutCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(map[string]interface{}{
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("login", "fizzy auth login <token>", "Log in again"),
+		}
+
+		printSuccessWithBreadcrumbs(map[string]interface{}{
 			"authenticated": false,
 			"message":       "Logged out successfully",
-		})
+		}, "", breadcrumbs)
 	},
 }
 
@@ -74,7 +87,13 @@ var authStatusCmd = &cobra.Command{
 			}
 		}
 
-		printSuccess(status)
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("identity", "fizzy identity show", "View identity"),
+			breadcrumb("logout", "fizzy auth logout", "Log out"),
+		}
+
+		printSuccessWithBreadcrumbs(status, "", breadcrumbs)
 	},
 }
 

--- a/internal/commands/identity.go
+++ b/internal/commands/identity.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +27,12 @@ var identityShowCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(resp.Data)
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("status", "fizzy auth status", "Auth status"),
+		}
+
+		printSuccessWithBreadcrumbs(resp.Data, "", breadcrumbs)
 	},
 }
 

--- a/internal/commands/notification.go
+++ b/internal/commands/notification.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -57,8 +58,23 @@ var notificationListCmd = &cobra.Command{
 			summary = fmt.Sprintf("%d notifications (%d unread, page %d)", count, unreadCount, notificationListPage)
 		}
 
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("read", "fizzy notification read <id>", "Mark as read"),
+			breadcrumb("read-all", "fizzy notification read-all", "Mark all as read"),
+			breadcrumb("show", "fizzy card show <card_number>", "View card"),
+		}
+
 		hasNext := resp.LinkNext != ""
-		printSuccessWithPaginationAndSummary(resp.Data, hasNext, resp.LinkNext, summary)
+		if hasNext {
+			nextPage := notificationListPage + 1
+			if nextPage == 0 {
+				nextPage = 2
+			}
+			breadcrumbs = append(breadcrumbs, breadcrumb("next", fmt.Sprintf("fizzy notification list --page %d", nextPage), "Next page"))
+		}
+
+		printSuccessWithPaginationAndBreadcrumbs(resp.Data, hasNext, resp.LinkNext, summary, breadcrumbs)
 	},
 }
 
@@ -78,7 +94,12 @@ var notificationReadCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(resp.Data)
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("notifications", "fizzy notification list", "List notifications"),
+		}
+
+		printSuccessWithBreadcrumbs(resp.Data, "", breadcrumbs)
 	},
 }
 
@@ -98,7 +119,12 @@ var notificationUnreadCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(resp.Data)
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("notifications", "fizzy notification list", "List notifications"),
+		}
+
+		printSuccessWithBreadcrumbs(resp.Data, "", breadcrumbs)
 	},
 }
 
@@ -117,7 +143,12 @@ var notificationReadAllCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(resp.Data)
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("notifications", "fizzy notification list", "List notifications"),
+		}
+
+		printSuccessWithBreadcrumbs(resp.Data, "", breadcrumbs)
 	},
 }
 

--- a/internal/commands/reaction.go
+++ b/internal/commands/reaction.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -55,7 +56,23 @@ var reactionListCmd = &cobra.Command{
 			summary = fmt.Sprintf("%d reactions on card #%s", count, reactionListCard)
 		}
 
-		printSuccessWithSummary(resp.Data, summary)
+		// Build breadcrumbs
+		var breadcrumbs []response.Breadcrumb
+		if reactionListComment != "" {
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("react", fmt.Sprintf("fizzy reaction create --card %s --comment %s --content \"👍\"", reactionListCard, reactionListComment), "Add reaction"),
+				breadcrumb("comment", fmt.Sprintf("fizzy comment show %s --card %s", reactionListComment, reactionListCard), "View comment"),
+				breadcrumb("show", fmt.Sprintf("fizzy card show %s", reactionListCard), "View card"),
+			}
+		} else {
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("react", fmt.Sprintf("fizzy reaction create --card %s --content \"👍\"", reactionListCard), "Add reaction"),
+				breadcrumb("comments", fmt.Sprintf("fizzy comment list --card %s", reactionListCard), "View comments"),
+				breadcrumb("show", fmt.Sprintf("fizzy card show %s", reactionListCard), "View card"),
+			}
+		}
+
+		printSuccessWithBreadcrumbs(resp.Data, summary, breadcrumbs)
 	},
 }
 
@@ -98,12 +115,26 @@ var reactionCreateCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		// Reaction create returns just success, no location or data
-		if resp.Data != nil {
-			printSuccess(resp.Data)
+		// Build breadcrumbs
+		var breadcrumbs []response.Breadcrumb
+		if reactionCreateComment != "" {
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("reactions", fmt.Sprintf("fizzy reaction list --card %s --comment %s", reactionCreateCard, reactionCreateComment), "List reactions"),
+				breadcrumb("comment", fmt.Sprintf("fizzy comment show %s --card %s", reactionCreateComment, reactionCreateCard), "View comment"),
+			}
 		} else {
-			printSuccess(map[string]interface{}{})
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("reactions", fmt.Sprintf("fizzy reaction list --card %s", reactionCreateCard), "List reactions"),
+				breadcrumb("show", fmt.Sprintf("fizzy card show %s", reactionCreateCard), "View card"),
+			}
 		}
+
+		// Reaction create returns just success, no location or data
+		data := resp.Data
+		if data == nil {
+			data = map[string]interface{}{}
+		}
+		printSuccessWithBreadcrumbs(data, "", breadcrumbs)
 	},
 }
 
@@ -139,9 +170,23 @@ var reactionDeleteCmd = &cobra.Command{
 			exitWithError(err)
 		}
 
-		printSuccess(map[string]interface{}{
+		// Build breadcrumbs
+		var breadcrumbs []response.Breadcrumb
+		if reactionDeleteComment != "" {
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("reactions", fmt.Sprintf("fizzy reaction list --card %s --comment %s", reactionDeleteCard, reactionDeleteComment), "List reactions"),
+				breadcrumb("comment", fmt.Sprintf("fizzy comment show %s --card %s", reactionDeleteComment, reactionDeleteCard), "View comment"),
+			}
+		} else {
+			breadcrumbs = []response.Breadcrumb{
+				breadcrumb("reactions", fmt.Sprintf("fizzy reaction list --card %s", reactionDeleteCard), "List reactions"),
+				breadcrumb("show", fmt.Sprintf("fizzy card show %s", reactionDeleteCard), "View card"),
+			}
+		}
+
+		printSuccessWithBreadcrumbs(map[string]interface{}{
 			"deleted": true,
-		})
+		}, "", breadcrumbs)
 	},
 }
 

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -230,6 +230,35 @@ func printSuccessWithPaginationAndSummary(data interface{}, hasNext bool, nextUR
 	os.Exit(errors.ExitSuccess)
 }
 
+// breadcrumb creates a single breadcrumb.
+func breadcrumb(action, cmd, description string) response.Breadcrumb {
+	return response.NewBreadcrumb(action, cmd, description)
+}
+
+// printSuccessWithBreadcrumbs prints a success response with breadcrumbs.
+func printSuccessWithBreadcrumbs(data interface{}, summary string, breadcrumbs []response.Breadcrumb) {
+	resp := response.SuccessWithBreadcrumbs(data, summary, breadcrumbs)
+	if lastResult != nil {
+		lastResult.Response = resp
+		lastResult.ExitCode = errors.ExitSuccess
+		panic(testExitSignal{}) // Signal to stop execution in test mode
+	}
+	resp.Print()
+	os.Exit(errors.ExitSuccess)
+}
+
+// printSuccessWithPaginationAndBreadcrumbs prints a success response with pagination and breadcrumbs.
+func printSuccessWithPaginationAndBreadcrumbs(data interface{}, hasNext bool, nextURL string, summary string, breadcrumbs []response.Breadcrumb) {
+	resp := response.SuccessWithPaginationAndBreadcrumbs(data, hasNext, nextURL, summary, breadcrumbs)
+	if lastResult != nil {
+		lastResult.Response = resp
+		lastResult.ExitCode = errors.ExitSuccess
+		panic(testExitSignal{}) // Signal to stop execution in test mode
+	}
+	resp.Print()
+	os.Exit(errors.ExitSuccess)
+}
+
 // SetTestMode configures the commands package for testing.
 // It sets a mock client factory and captures results instead of exiting.
 func SetTestMode(mockClient client.API) *CommandResult {

--- a/internal/commands/search.go
+++ b/internal/commands/search.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -81,8 +82,14 @@ var searchCmd = &cobra.Command{
 			summary = fmt.Sprintf("%d results for \"%s\" (page %d)", count, query, searchPage)
 		}
 
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("show", "fizzy card show <number>", "View card details"),
+			breadcrumb("narrow", fmt.Sprintf("fizzy search \"%s\" --board <id>", query), "Filter by board"),
+		}
+
 		hasNext := resp.LinkNext != ""
-		printSuccessWithPaginationAndSummary(resp.Data, hasNext, resp.LinkNext, summary)
+		printSuccessWithPaginationAndBreadcrumbs(resp.Data, hasNext, resp.LinkNext, summary, breadcrumbs)
 	},
 }
 

--- a/internal/commands/tag.go
+++ b/internal/commands/tag.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/robzolkos/fizzy-cli/internal/response"
 	"github.com/spf13/cobra"
 )
 
@@ -49,8 +50,22 @@ var tagListCmd = &cobra.Command{
 			summary += fmt.Sprintf(" (page %d)", tagListPage)
 		}
 
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("tag", "fizzy card tag <number> --tag <name>", "Tag a card"),
+			breadcrumb("cards", "fizzy card list --tag <id>", "List cards with tag"),
+		}
+
 		hasNext := resp.LinkNext != ""
-		printSuccessWithPaginationAndSummary(resp.Data, hasNext, resp.LinkNext, summary)
+		if hasNext {
+			nextPage := tagListPage + 1
+			if nextPage == 0 {
+				nextPage = 2
+			}
+			breadcrumbs = append(breadcrumbs, breadcrumb("next", fmt.Sprintf("fizzy tag list --page %d", nextPage), "Next page"))
+		}
+
+		printSuccessWithPaginationAndBreadcrumbs(resp.Data, hasNext, resp.LinkNext, summary, breadcrumbs)
 	},
 }
 

--- a/internal/response/response.go
+++ b/internal/response/response.go
@@ -21,13 +21,14 @@ func SetPrettyPrint(enabled bool) {
 
 // Response represents the JSON response envelope.
 type Response struct {
-	Success    bool                   `json:"success"`
-	Data       interface{}            `json:"data,omitempty"`
-	Error      *ErrorDetail           `json:"error,omitempty"`
-	Pagination *Pagination            `json:"pagination,omitempty"`
-	Location   string                 `json:"location,omitempty"`
-	Summary    string                 `json:"summary,omitempty"`
-	Meta       map[string]interface{} `json:"meta,omitempty"`
+	Success     bool                   `json:"success"`
+	Data        interface{}            `json:"data,omitempty"`
+	Error       *ErrorDetail           `json:"error,omitempty"`
+	Pagination  *Pagination            `json:"pagination,omitempty"`
+	Breadcrumbs []Breadcrumb           `json:"breadcrumbs,omitempty"`
+	Location    string                 `json:"location,omitempty"`
+	Summary     string                 `json:"summary,omitempty"`
+	Meta        map[string]interface{} `json:"meta,omitempty"`
 }
 
 // ErrorDetail represents an error in the response.
@@ -42,6 +43,22 @@ type ErrorDetail struct {
 type Pagination struct {
 	HasNext bool   `json:"has_next"`
 	NextURL string `json:"next_url,omitempty"`
+}
+
+// Breadcrumb represents a suggested next action.
+type Breadcrumb struct {
+	Action      string `json:"action"`
+	Cmd         string `json:"cmd"`
+	Description string `json:"description"`
+}
+
+// NewBreadcrumb creates a new breadcrumb.
+func NewBreadcrumb(action, cmd, description string) Breadcrumb {
+	return Breadcrumb{
+		Action:      action,
+		Cmd:         cmd,
+		Description: description,
+	}
 }
 
 // Success creates a successful response with data.
@@ -96,6 +113,35 @@ func SuccessWithPaginationAndSummary(data interface{}, hasNext bool, nextURL str
 		Data:    data,
 		Summary: summary,
 		Meta:    createMeta(),
+	}
+	if hasNext || nextURL != "" {
+		resp.Pagination = &Pagination{
+			HasNext: hasNext,
+			NextURL: nextURL,
+		}
+	}
+	return resp
+}
+
+// SuccessWithBreadcrumbs creates a successful response with breadcrumbs.
+func SuccessWithBreadcrumbs(data interface{}, summary string, breadcrumbs []Breadcrumb) *Response {
+	return &Response{
+		Success:     true,
+		Data:        data,
+		Summary:     summary,
+		Breadcrumbs: breadcrumbs,
+		Meta:        createMeta(),
+	}
+}
+
+// SuccessWithPaginationAndBreadcrumbs creates a successful response with pagination, summary, and breadcrumbs.
+func SuccessWithPaginationAndBreadcrumbs(data interface{}, hasNext bool, nextURL string, summary string, breadcrumbs []Breadcrumb) *Response {
+	resp := &Response{
+		Success:     true,
+		Data:        data,
+		Summary:     summary,
+		Breadcrumbs: breadcrumbs,
+		Meta:        createMeta(),
 	}
 	if hasNext || nextURL != "" {
 		resp.Pagination = &Pagination{


### PR DESCRIPTION
## Summary

- Add breadcrumbs feature to CLI responses - contextual "what can I do next?" suggestions
- Designed for AI agents to discover workflows without knowing the full CLI
- Also helpful for human users to learn available commands contextually

## Changes

- Add `Breadcrumb` type with `action`, `cmd`, and `description` fields
- Add `breadcrumbs` array to Response struct (omitted when empty)
- Add helper functions: `NewBreadcrumb()`, `SuccessWithBreadcrumbs()`, `SuccessWithPaginationAndBreadcrumbs()`
- Add breadcrumbs to all commands (card, board, column, comment, step, reaction, user, tag, notification, search, auth, identity)
- Dynamic values (card numbers, board IDs, etc.) are interpolated into command suggestions
- Add unit tests for breadcrumb functionality
- Document breadcrumbs in README

## Example

```bash
fizzy card show 42 | jq '.breadcrumbs'
```

```json
[
  {"action": "comment", "cmd": "fizzy comment create --card 42 --body \"text\"", "description": "Add comment"},
  {"action": "triage", "cmd": "fizzy card column 42 --column <column_id>", "description": "Move to column"},
  {"action": "close", "cmd": "fizzy card close 42", "description": "Close card"},
  {"action": "assign", "cmd": "fizzy card assign 42 --user <user_id>", "description": "Assign user"}
]
```

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] E2E tested with live API - verified breadcrumbs present in responses
- [x] E2E validated that breadcrumb command suggestions actually work when executed
- [x] Tested card, board, column, comment, step, reaction, user, tag, notification, search, auth commands