### PR TITLE
Prevent path traversal in attachment downloads

### DIFF
--- a/internal/commands/attachment.go
+++ b/internal/commands/attachment.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"path/filepath"
 	"regexp"
 	"strconv"
 
@@ -112,7 +113,8 @@ Use 'fizzy card attachments show CARD_NUMBER' to see available attachments and t
 		// Download the files
 		var results []map[string]interface{}
 		for _, attachment := range toDownload {
-			outputPath := attachment.Filename
+			// Sanitize filename to prevent path traversal attacks
+			outputPath := filepath.Base(attachment.Filename)
 			// If downloading single file with custom output name
 			if len(toDownload) == 1 && attachmentDownloadOutput != "" {
 				outputPath = attachmentDownloadOutput


### PR DESCRIPTION
## Summary
- Sanitize attachment filenames using `filepath.Base()` before writing to disk
- Prevents potential path traversal attacks where a malicious filename could write outside the current directory

## Details
When downloading attachments, the CLI now strips any directory components from filenames. This ensures files are always written to the current directory, regardless of what the server returns.

While Fizzy's API is trusted, this follows defense-in-depth principles - the CLI should never write to arbitrary filesystem locations based on external input.

## Test plan
- [x] Unit tests added covering path traversal attempts (`../`, absolute paths, nested traversal)
- [x] Unit tests verify normal filenames are unchanged
- [x] E2E attachment tests pass (upload, download, show all work correctly)