### PR TITLE
Add gofmt hook to auto-format Go files on edit

### DIFF
--- a/.claude/hooks/format.sh
+++ b/.claude/hooks/format.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+file_path=$(jq -r '.tool_input.file_path')
+[[ -z "$file_path" ]] && exit 0
+
+if [[ "$file_path" == *.go ]]; then
+  gofmt -w "$file_path" 2>/dev/null || true
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/format.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Claude Code PostToolUse hook that runs `gofmt` on any `.go` file after Edit or Write operations
- Ensures consistent Go formatting across the team when using Claude Code

## Test plan
- [x] Verified hook runs automatically after editing Go files
- [x] Verified badly formatted code gets auto-corrected
- [x] Verified non-Go files are unaffected