### PR TITLE
Adds the ability to download attachments that are in comments

### DIFF
--- a/internal/commands/comment_attachment.go
+++ b/internal/commands/comment_attachment.go
@@ -1,0 +1,198 @@
+package commands
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/robzolkos/fizzy-cli/internal/errors"
+	"github.com/robzolkos/fizzy-cli/internal/response"
+	"github.com/spf13/cobra"
+)
+
+// CommentAttachment extends Attachment with comment context
+type CommentAttachment struct {
+	Attachment
+	CommentID string `json:"comment_id"`
+}
+
+var commentAttachmentsCmd = &cobra.Command{
+	Use:   "attachments",
+	Short: "Manage comment attachments",
+	Long:  "Commands for viewing and downloading attachments embedded in comments.",
+}
+
+// Comment attachments show flags
+var commentAttachmentsShowCard string
+
+var commentAttachmentsShowCmd = &cobra.Command{
+	Use:   "show",
+	Short: "List attachments in comments",
+	Long:  "Lists all attachments embedded in comment bodies for a card.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		if commentAttachmentsShowCard == "" {
+			exitWithError(newRequiredFlagError("card"))
+		}
+
+		client := getClient()
+		path := "/cards/" + commentAttachmentsShowCard + "/comments.json"
+		resp, err := client.GetWithPagination(path, true)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		comments, ok := resp.Data.([]interface{})
+		if !ok {
+			exitWithError(errors.NewError("Invalid comments response"))
+		}
+
+		attachments := extractCommentAttachments(comments)
+
+		summary := fmt.Sprintf("%d attachments across %d comments on card #%s", len(attachments), len(comments), commentAttachmentsShowCard)
+
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("download", fmt.Sprintf("fizzy comment attachments download --card %s", commentAttachmentsShowCard), "Download attachments"),
+			breadcrumb("comments", fmt.Sprintf("fizzy comment list --card %s", commentAttachmentsShowCard), "List comments"),
+			breadcrumb("card-attachments", fmt.Sprintf("fizzy card attachments show %s", commentAttachmentsShowCard), "Card attachments"),
+		}
+
+		printSuccessWithBreadcrumbs(attachments, summary, breadcrumbs)
+	},
+}
+
+// Comment attachments download flags
+var commentAttachmentsDownloadCard string
+var commentAttachmentsDownloadOutput string
+
+var commentAttachmentsDownloadCmd = &cobra.Command{
+	Use:   "download [ATTACHMENT_INDEX]",
+	Short: "Download attachments from comments",
+	Long: `Downloads attachments embedded in comment bodies for a card.
+
+If ATTACHMENT_INDEX is provided, downloads only that attachment (1-based index).
+If ATTACHMENT_INDEX is omitted, downloads all comment attachments.
+
+When downloading a single attachment, -o sets the exact output filename.
+When downloading multiple attachments, -o sets a prefix (e.g. -o test produces test_1.png, test_2.png).
+
+Use 'fizzy comment attachments show --card CARD_NUMBER' to see available attachments and their indices.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		if commentAttachmentsDownloadCard == "" {
+			exitWithError(newRequiredFlagError("card"))
+		}
+
+		client := getClient()
+		path := "/cards/" + commentAttachmentsDownloadCard + "/comments.json"
+		resp, err := client.GetWithPagination(path, true)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		comments, ok := resp.Data.([]interface{})
+		if !ok {
+			exitWithError(errors.NewError("Invalid comments response"))
+		}
+
+		attachments := extractCommentAttachments(comments)
+
+		if len(attachments) == 0 {
+			exitWithError(errors.NewNotFoundError("No attachments found in comments on this card"))
+		}
+
+		// Determine which attachments to download
+		var toDownload []CommentAttachment
+		if len(args) == 1 {
+			attachmentIndex, err := strconv.Atoi(args[0])
+			if err != nil {
+				exitWithError(errors.NewInvalidArgsError("attachment index must be a number"))
+			}
+			if attachmentIndex < 1 || attachmentIndex > len(attachments) {
+				exitWithError(errors.NewInvalidArgsError("attachment index must be between 1 and " + strconv.Itoa(len(attachments))))
+			}
+			toDownload = []CommentAttachment{attachments[attachmentIndex-1]}
+		} else {
+			toDownload = attachments
+		}
+
+		// Download the files
+		var results []map[string]interface{}
+		for i, attachment := range toDownload {
+			outputPath := buildOutputPath(commentAttachmentsDownloadOutput, attachment.Filename, i+1, len(toDownload))
+
+			if err := client.DownloadFile(attachment.DownloadURL, outputPath); err != nil {
+				exitWithError(err)
+			}
+
+			results = append(results, map[string]interface{}{
+				"filename":   attachment.Filename,
+				"saved_to":   outputPath,
+				"filesize":   attachment.Filesize,
+				"comment_id": attachment.CommentID,
+			})
+		}
+
+		printSuccess(map[string]interface{}{
+			"downloaded": len(results),
+			"files":      results,
+		})
+	},
+}
+
+// extractCommentAttachments parses all comments and returns attachments with comment context
+func extractCommentAttachments(comments []interface{}) []CommentAttachment {
+	var allAttachments []CommentAttachment
+	globalIndex := 1
+
+	for _, c := range comments {
+		comment, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		commentID, _ := comment["id"].(string)
+
+		// Comment body is an object with html and plain_text fields
+		bodyObj, ok := comment["body"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		bodyHTML, _ := bodyObj["html"].(string)
+		if bodyHTML == "" {
+			continue
+		}
+
+		attachments := parseAttachments(bodyHTML)
+		for _, a := range attachments {
+			a.Index = globalIndex
+			globalIndex++
+			allAttachments = append(allAttachments, CommentAttachment{
+				Attachment: a,
+				CommentID:  commentID,
+			})
+		}
+	}
+
+	return allAttachments
+}
+
+func init() {
+	commentCmd.AddCommand(commentAttachmentsCmd)
+
+	// Show
+	commentAttachmentsShowCmd.Flags().StringVar(&commentAttachmentsShowCard, "card", "", "Card number (required)")
+	commentAttachmentsCmd.AddCommand(commentAttachmentsShowCmd)
+
+	// Download
+	commentAttachmentsDownloadCmd.Flags().StringVar(&commentAttachmentsDownloadCard, "card", "", "Card number (required)")
+	commentAttachmentsDownloadCmd.Flags().StringVarP(&commentAttachmentsDownloadOutput, "output", "o", "", "Output filename (single file) or prefix (multiple files, e.g. -o test produces test_1.png)")
+	commentAttachmentsCmd.AddCommand(commentAttachmentsDownloadCmd)
+}

--- a/internal/commands/comment_attachment_test.go
+++ b/internal/commands/comment_attachment_test.go
@@ -1,0 +1,364 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/robzolkos/fizzy-cli/internal/client"
+	"github.com/robzolkos/fizzy-cli/internal/errors"
+)
+
+func TestExtractCommentAttachments(t *testing.T) {
+	tests := []struct {
+		name          string
+		comments      []interface{}
+		expectedCount int
+		expectedFirst *CommentAttachment
+	}{
+		{
+			name: "comment with attachment",
+			comments: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="screenshot.png" filesize="5000" width="800" height="600">
+							<a href="/blobs/blob1/screenshot.png?disposition=attachment">Download</a>
+						</action-text-attachment>`,
+						"plain_text": "screenshot.png",
+					},
+				},
+			},
+			expectedCount: 1,
+			expectedFirst: &CommentAttachment{
+				Attachment: Attachment{
+					Index:       1,
+					Filename:    "screenshot.png",
+					ContentType: "image/png",
+					Filesize:    5000,
+					Width:       800,
+					Height:      600,
+					SGID:        "sgid1",
+					DownloadURL: "/blobs/blob1/screenshot.png?disposition=attachment",
+				},
+				CommentID: "comment-1",
+			},
+		},
+		{
+			name: "multiple comments with attachments",
+			comments: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="img1.png" filesize="1000">
+							<a href="/blobs/blob1/img1.png?disposition=attachment">Download</a>
+						</action-text-attachment>`,
+					},
+				},
+				map[string]interface{}{
+					"id": "comment-2",
+					"body": map[string]interface{}{
+						"html": `<action-text-attachment sgid="sgid2" content-type="image/jpeg" filename="img2.jpg" filesize="2000">
+							<a href="/blobs/blob2/img2.jpg?disposition=attachment">Download</a>
+						</action-text-attachment>`,
+					},
+				},
+			},
+			expectedCount: 2,
+		},
+		{
+			name: "comment without attachments",
+			comments: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html":       "<p>Just text</p>",
+						"plain_text": "Just text",
+					},
+				},
+			},
+			expectedCount: 0,
+		},
+		{
+			name:          "empty comments",
+			comments:      []interface{}{},
+			expectedCount: 0,
+		},
+		{
+			name: "mixed comments with and without attachments",
+			comments: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html": "<p>No attachment here</p>",
+					},
+				},
+				map[string]interface{}{
+					"id": "comment-2",
+					"body": map[string]interface{}{
+						"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="found.png" filesize="3000">
+							<a href="/blobs/blob1/found.png?disposition=attachment">Download</a>
+						</action-text-attachment>`,
+					},
+				},
+			},
+			expectedCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractCommentAttachments(tt.comments)
+
+			if len(result) != tt.expectedCount {
+				t.Errorf("expected %d attachments, got %d", tt.expectedCount, len(result))
+				return
+			}
+
+			if tt.expectedFirst != nil && len(result) > 0 {
+				actual := result[0]
+				if actual.Index != tt.expectedFirst.Index {
+					t.Errorf("expected index %d, got %d", tt.expectedFirst.Index, actual.Index)
+				}
+				if actual.Filename != tt.expectedFirst.Filename {
+					t.Errorf("expected filename %q, got %q", tt.expectedFirst.Filename, actual.Filename)
+				}
+				if actual.CommentID != tt.expectedFirst.CommentID {
+					t.Errorf("expected comment_id %q, got %q", tt.expectedFirst.CommentID, actual.CommentID)
+				}
+				if actual.DownloadURL != tt.expectedFirst.DownloadURL {
+					t.Errorf("expected download_url %q, got %q", tt.expectedFirst.DownloadURL, actual.DownloadURL)
+				}
+			}
+
+			// Verify global indexing is sequential
+			for i, a := range result {
+				if a.Index != i+1 {
+					t.Errorf("attachment %d: expected index %d, got %d", i, i+1, a.Index)
+				}
+			}
+		})
+	}
+}
+
+func TestCommentAttachmentsShowCommand(t *testing.T) {
+	t.Run("shows attachments from comments", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="test.png" filesize="1000">
+							<a href="/blobs/blob1/test.png?disposition=attachment">Download</a>
+						</action-text-attachment>`,
+					},
+				},
+			},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsShowCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsShowCmd.Run(commentAttachmentsShowCmd, []string{})
+		})
+		commentAttachmentsShowCard = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if !result.Response.Success {
+			t.Errorf("expected success, got error")
+		}
+		if mock.GetWithPaginationCalls[0].Path != "/cards/172/comments.json" {
+			t.Errorf("expected path '/cards/172/comments.json', got '%s'", mock.GetWithPaginationCalls[0].Path)
+		}
+	})
+
+	t.Run("requires card flag", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsShowCard = ""
+		RunTestCommand(func() {
+			commentAttachmentsShowCmd.Run(commentAttachmentsShowCmd, []string{})
+		})
+
+		if result.ExitCode != errors.ExitInvalidArgs {
+			t.Errorf("expected exit code %d, got %d", errors.ExitInvalidArgs, result.ExitCode)
+		}
+	})
+}
+
+func TestCommentAttachmentsDownloadCommand(t *testing.T) {
+	commentsWithAttachment := []interface{}{
+		map[string]interface{}{
+			"id": "comment-1",
+			"body": map[string]interface{}{
+				"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="test.png" filesize="1000">
+					<a href="/blobs/blob1/test.png?disposition=attachment">Download</a>
+				</action-text-attachment>`,
+			},
+		},
+	}
+
+	commentsWithMultipleAttachments := []interface{}{
+		map[string]interface{}{
+			"id": "comment-1",
+			"body": map[string]interface{}{
+				"html": `<action-text-attachment sgid="sgid1" content-type="image/png" filename="img1.png" filesize="1000">
+					<a href="/blobs/blob1/img1.png?disposition=attachment">Download</a>
+				</action-text-attachment>
+				<action-text-attachment sgid="sgid2" content-type="application/pdf" filename="doc.pdf" filesize="2000">
+					<a href="/blobs/blob2/doc.pdf?disposition=attachment">Download</a>
+				</action-text-attachment>`,
+			},
+		},
+	}
+
+	t.Run("downloads all comment attachments", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       commentsWithMultipleAttachments,
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{})
+		})
+		commentAttachmentsDownloadCard = ""
+
+		if !result.Response.Success {
+			t.Errorf("expected success, got error: %v", result.Response)
+		}
+		if len(mock.DownloadFileCalls) != 2 {
+			t.Errorf("expected 2 downloads, got %d", len(mock.DownloadFileCalls))
+		}
+	})
+
+	t.Run("downloads single attachment by index", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       commentsWithAttachment,
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{"1"})
+		})
+		commentAttachmentsDownloadCard = ""
+
+		if !result.Response.Success {
+			t.Errorf("expected success, got error: %v", result.Response)
+		}
+		if len(mock.DownloadFileCalls) != 1 {
+			t.Errorf("expected 1 download, got %d", len(mock.DownloadFileCalls))
+		}
+		if mock.DownloadFileCalls[0].URLPath != "/blobs/blob1/test.png?disposition=attachment" {
+			t.Errorf("expected download URL '/blobs/blob1/test.png?disposition=attachment', got '%s'", mock.DownloadFileCalls[0].URLPath)
+		}
+	})
+
+	t.Run("errors on no attachments", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data: []interface{}{
+				map[string]interface{}{
+					"id": "comment-1",
+					"body": map[string]interface{}{
+						"html": "<p>No images here</p>",
+					},
+				},
+			},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{})
+		})
+		commentAttachmentsDownloadCard = ""
+
+		if result.Response.Success {
+			t.Error("expected error, got success")
+		}
+	})
+
+	t.Run("errors on invalid index", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       commentsWithAttachment,
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{"abc"})
+		})
+		commentAttachmentsDownloadCard = ""
+
+		if result.Response.Success {
+			t.Error("expected error for non-numeric index")
+		}
+	})
+
+	t.Run("errors on out of range index", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       commentsWithAttachment,
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = "172"
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{"5"})
+		})
+		commentAttachmentsDownloadCard = ""
+
+		if result.Response.Success {
+			t.Error("expected error for out of range index")
+		}
+	})
+
+	t.Run("requires card flag", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		commentAttachmentsDownloadCard = ""
+		RunTestCommand(func() {
+			commentAttachmentsDownloadCmd.Run(commentAttachmentsDownloadCmd, []string{})
+		})
+
+		if result.ExitCode != errors.ExitInvalidArgs {
+			t.Errorf("expected exit code %d, got %d", errors.ExitInvalidArgs, result.ExitCode)
+		}
+	})
+}

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -15,7 +15,7 @@ Manage Fizzy boards, cards, steps, comments, reactions, and pins.
 | card | `card list` | `card show NUMBER` | `card create` | `card update NUMBER` | `card delete NUMBER` | `card move NUMBER` |
 | search | `search QUERY` | - | - | - | - | - |
 | column | `column list --board ID` | `column show ID --board ID` | `column create` | `column update ID` | `column delete ID` | - |
-| comment | `comment list --card NUMBER` | `comment show ID --card NUMBER` | `comment create` | `comment update ID` | `comment delete ID` | - |
+| comment | `comment list --card NUMBER` | `comment show ID --card NUMBER` | `comment create` | `comment update ID` | `comment delete ID` | `comment attachments show --card NUMBER` |
 | step | - | `step show ID --card NUMBER` | `step create` | `step update ID` | `step delete ID` | - |
 | reaction | `reaction list` | - | `reaction create` | - | `reaction delete ID` | - |
 | tag | `tag list` | - | - | - | - | - |
@@ -546,9 +546,9 @@ fizzy card image-remove CARD_NUMBER           # Remove header image
 #### Attachments
 
 ```bash
-fizzy card attachments show CARD_NUMBER                    # List attachments
-fizzy card attachments download CARD_NUMBER [INDEX]        # Download (1-based index)
-  -o, --output FILENAME                                    # Output filename (single file)
+fizzy card attachments show CARD_NUMBER [--include-comments]           # List attachments
+fizzy card attachments download CARD_NUMBER [INDEX] [--include-comments]  # Download (1-based index)
+  -o, --output FILENAME                                    # Exact name (single) or prefix (multiple: test_1.png, test_2.png)
 ```
 
 ### Columns
@@ -571,6 +571,14 @@ fizzy comment show COMMENT_ID --card NUMBER
 fizzy comment create --card NUMBER --body "HTML" [--body_file PATH] [--created-at TIMESTAMP]
 fizzy comment update COMMENT_ID --card NUMBER [--body "HTML"] [--body_file PATH]
 fizzy comment delete COMMENT_ID --card NUMBER
+```
+
+#### Comment Attachments
+
+```bash
+fizzy comment attachments show --card NUMBER                  # List attachments in comments
+fizzy comment attachments download --card NUMBER [INDEX]      # Download (1-based index)
+  -o, --output FILENAME                                       # Exact name (single) or prefix (multiple: test_1.png, test_2.png)
 ```
 
 ### Steps (To-Do Items)


### PR DESCRIPTION
**Disclaimer: This was AI generated and could be sloppy.**

I had issues downloading images when they were in comments instead of the card body. This PR seems to be working well for me and I'd like to share it.

```
$ fizzy card attachments download CARD_NUMBER [INDEX] [--include-comments] 
$ fizzy comment attachments show --card NUMBER                 
$ fizzy comment attachments download --card NUMBER [INDEX] 
  -o, --output FILENAME                                       # Exact name (single) or prefix (multiple: 'test' for test_1.png, test_2.png)
```