### PR TITLE
Add has_attachments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,11 @@ fizzy card ungolden 42
 
 ### Card Attachments
 
+> **Tip:** Use `has_attachments` to check which cards have attachments before fetching them:
+> ```bash
+> fizzy card list | jq '[.data[] | select(.has_attachments) | {number, title}]'
+> ```
+
 ```bash
 # List attachments on a card
 fizzy card attachments show 42

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -146,6 +146,7 @@ Complete field reference for all resources. Use these exact field paths in jq qu
 | `closed` | boolean | true = card is closed |
 | `golden` | boolean | true = starred/important |
 | `image_url` | string/null | Header/background image URL |
+| `has_attachments` | boolean | true = card has file attachments |
 | `has_more_assignees` | boolean | More assignees than shown |
 | `created_at` | timestamp | ISO 8601 |
 | `last_active_at` | timestamp | ISO 8601 |


### PR DESCRIPTION
## Summary

- Document `has_attachments` boolean field (from Fizzy PR #2455) in SKILL.md card schema and README card attachments section
- Add `TestCardHasAttachments` e2e test verifying the field is `false` for plain cards and `true` for cards with inline attachments