### PR TITLE
Add user update command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ help:
 	@echo "  FIZZY_TEST_TOKEN   API token"
 	@echo "  FIZZY_TEST_ACCOUNT Account slug"
 	@echo "  FIZZY_TEST_API_URL API base URL (default: https://app.fizzy.do)"
+	@echo "  FIZZY_TEST_USER_ID User ID for user update/deactivate tests (optional)"
 	@echo ""
 	@echo "Examples:"
 	@echo "  make build"

--- a/README.md
+++ b/README.md
@@ -413,6 +413,9 @@ fizzy reaction delete REACTION_ID --card 42 --comment COMMENT_ID
 ```bash
 fizzy user list
 fizzy user show USER_ID
+fizzy user update USER_ID --name "New Name"
+fizzy user update USER_ID --avatar /path/to/avatar.jpg
+fizzy user update USER_ID --name "New Name" --avatar /path/to/avatar.jpg
 ```
 
 ### Tags
@@ -692,6 +695,9 @@ make test-unit
 # Set required environment variables
 export FIZZY_TEST_TOKEN=your-api-token
 export FIZZY_TEST_ACCOUNT=your-account-slug
+
+# Optional: set a test user ID for user update/deactivate tests
+export FIZZY_TEST_USER_ID=your-test-user-id
 
 # Build and run e2e tests
 make test-e2e

--- a/e2e/harness/harness.go
+++ b/e2e/harness/harness.go
@@ -80,6 +80,7 @@ type Config struct {
 	Token      string
 	Account    string
 	APIURL     string
+	UserID     string
 }
 
 // Exit codes used by the CLI.
@@ -107,6 +108,7 @@ func LoadConfig() *Config {
 		Token:      os.Getenv("FIZZY_TEST_TOKEN"),
 		Account:    os.Getenv("FIZZY_TEST_ACCOUNT"),
 		APIURL:     getEnvOrDefault("FIZZY_TEST_API_URL", "https://app.fizzy.do"),
+		UserID:     os.Getenv("FIZZY_TEST_USER_ID"),
 	}
 }
 

--- a/e2e/tests/user_test.go
+++ b/e2e/tests/user_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/robzolkos/fizzy-cli/e2e/harness"
@@ -123,5 +125,139 @@ func TestUserShowNotFound(t *testing.T) {
 	})
 }
 
-// Note: We don't test user update/deactivate as they would modify real users
-// These should be tested manually or with a dedicated test account
+func TestUserUpdate(t *testing.T) {
+	cfg := harness.LoadConfig()
+	if cfg.UserID == "" {
+		t.Skip("FIZZY_TEST_USER_ID not set, skipping user update tests")
+	}
+
+	h := harness.New(t)
+	userID := cfg.UserID
+
+	// First get the current name so we can restore it
+	showResult := h.Run("user", "show", userID)
+	if showResult.ExitCode != harness.ExitSuccess {
+		t.Fatalf("failed to show test user: %s", showResult.Stderr)
+	}
+	originalName := showResult.GetDataString("name")
+	if originalName == "" {
+		t.Fatal("expected test user to have a name")
+	}
+
+	t.Run("update user name", func(t *testing.T) {
+		newName := originalName + " Updated"
+		result := h.Run("user", "update", userID, "--name", newName)
+
+		if result.ExitCode != harness.ExitSuccess {
+			t.Errorf("expected exit code %d, got %d\nstderr: %s", harness.ExitSuccess, result.ExitCode, result.Stderr)
+		}
+
+		if !result.Response.Success {
+			t.Errorf("expected success=true, error: %+v", result.Response.Error)
+		}
+
+		// Verify the name was updated
+		verifyResult := h.Run("user", "show", userID)
+		if verifyResult.ExitCode == harness.ExitSuccess {
+			name := verifyResult.GetDataString("name")
+			if name != newName {
+				t.Errorf("expected name %q, got %q", newName, name)
+			}
+		}
+	})
+
+	t.Run("restore original name", func(t *testing.T) {
+		result := h.Run("user", "update", userID, "--name", originalName)
+
+		if result.ExitCode != harness.ExitSuccess {
+			t.Errorf("expected exit code %d, got %d\nstderr: %s", harness.ExitSuccess, result.ExitCode, result.Stderr)
+		}
+
+		if !result.Response.Success {
+			t.Errorf("expected success=true, error: %+v", result.Response.Error)
+		}
+
+		// Verify restored
+		verifyResult := h.Run("user", "show", userID)
+		if verifyResult.ExitCode == harness.ExitSuccess {
+			name := verifyResult.GetDataString("name")
+			if name != originalName {
+				t.Errorf("expected name %q, got %q", originalName, name)
+			}
+		}
+	})
+
+	t.Run("update user avatar", func(t *testing.T) {
+		wd, _ := os.Getwd()
+		fixturePath := filepath.Join(wd, "..", "testdata", "fixtures", "test_image.png")
+		if _, err := os.Stat(fixturePath); os.IsNotExist(err) {
+			t.Skipf("test fixture not found at %s", fixturePath)
+		}
+
+		result := h.Run("user", "update", userID, "--avatar", fixturePath)
+
+		if result.ExitCode != harness.ExitSuccess {
+			t.Errorf("expected exit code %d, got %d\nstderr: %s\nstdout: %s", harness.ExitSuccess, result.ExitCode, result.Stderr, result.Stdout)
+		}
+
+		if !result.Response.Success {
+			t.Errorf("expected success=true, error: %+v", result.Response.Error)
+		}
+
+		// Verify user still has an avatar URL
+		verifyResult := h.Run("user", "show", userID)
+		if verifyResult.ExitCode == harness.ExitSuccess {
+			avatarURL := verifyResult.GetDataString("avatar_url")
+			if avatarURL == "" {
+				t.Error("expected user to have an avatar_url after upload")
+			}
+		}
+	})
+
+	t.Run("update name and avatar together", func(t *testing.T) {
+		wd, _ := os.Getwd()
+		fixturePath := filepath.Join(wd, "..", "testdata", "fixtures", "test_image.png")
+		if _, err := os.Stat(fixturePath); os.IsNotExist(err) {
+			t.Skipf("test fixture not found at %s", fixturePath)
+		}
+
+		newName := originalName + " WithAvatar"
+		result := h.Run("user", "update", userID, "--name", newName, "--avatar", fixturePath)
+
+		if result.ExitCode != harness.ExitSuccess {
+			t.Errorf("expected exit code %d, got %d\nstderr: %s\nstdout: %s", harness.ExitSuccess, result.ExitCode, result.Stderr, result.Stdout)
+		}
+
+		if !result.Response.Success {
+			t.Errorf("expected success=true, error: %+v", result.Response.Error)
+		}
+
+		// Verify name was updated
+		verifyResult := h.Run("user", "show", userID)
+		if verifyResult.ExitCode == harness.ExitSuccess {
+			name := verifyResult.GetDataString("name")
+			if name != newName {
+				t.Errorf("expected name %q, got %q", newName, name)
+			}
+		}
+
+		// Restore original name
+		h.Run("user", "update", userID, "--name", originalName)
+	})
+
+	t.Run("update non-existent user returns not found", func(t *testing.T) {
+		result := h.Run("user", "update", "non-existent-user-id-12345", "--name", "Nope")
+
+		if result.ExitCode != harness.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d\nstdout: %s", harness.ExitNotFound, result.ExitCode, result.Stdout)
+		}
+
+		if result.Response == nil {
+			t.Fatal("expected JSON response")
+		}
+
+		if result.Response.Success {
+			t.Error("expected success=false")
+		}
+	})
+}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -85,6 +85,75 @@ func (c *Client) Patch(path string, body interface{}) (*APIResponse, error) {
 	return c.request("PATCH", path, body)
 }
 
+// PatchMultipart performs a PATCH request with multipart form data.
+func (c *Client) PatchMultipart(path, fileField, filePath string, fields map[string]string) (*APIResponse, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.NewError(fmt.Sprintf("Failed to open file: %v", err))
+	}
+	defer file.Close()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	part, err := writer.CreateFormFile(fileField, filepath.Base(filePath))
+	if err != nil {
+		return nil, errors.NewError(fmt.Sprintf("Failed to create form file: %v", err))
+	}
+
+	if _, err := io.Copy(part, file); err != nil {
+		return nil, errors.NewError(fmt.Sprintf("Failed to copy file: %v", err))
+	}
+
+	for key, value := range fields {
+		if err := writer.WriteField(key, value); err != nil {
+			return nil, errors.NewError(fmt.Sprintf("Failed to write form field: %v", err))
+		}
+	}
+
+	if err := writer.Close(); err != nil {
+		return nil, errors.NewError(fmt.Sprintf("Failed to finalize multipart body: %v", err))
+	}
+
+	reqURL := c.buildURL(path)
+	req, err := http.NewRequest("PATCH", reqURL, &buf)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Failed to create request: %v", err))
+	}
+
+	c.setHeaders(req)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Request failed: %v", err))
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.NewNetworkError(fmt.Sprintf("Failed to read response: %v", err))
+	}
+
+	apiResp := &APIResponse{
+		StatusCode: resp.StatusCode,
+		Body:       respBody,
+		Location:   resp.Header.Get("Location"),
+	}
+
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &apiResp.Data); err != nil {
+			return apiResp, nil
+		}
+	}
+
+	if resp.StatusCode >= 400 {
+		return apiResp, c.errorFromResponse(resp.StatusCode, respBody)
+	}
+
+	return apiResp, nil
+}
+
 // Put performs a PUT request with JSON body.
 func (c *Client) Put(path string, body interface{}) (*APIResponse, error) {
 	return c.request("PUT", path, body)

--- a/internal/client/interface.go
+++ b/internal/client/interface.go
@@ -6,6 +6,7 @@ type API interface {
 	Get(path string) (*APIResponse, error)
 	Post(path string, body interface{}) (*APIResponse, error)
 	Patch(path string, body interface{}) (*APIResponse, error)
+	PatchMultipart(path, fileField, filePath string, fields map[string]string) (*APIResponse, error)
 	Put(path string, body interface{}) (*APIResponse, error)
 	Delete(path string) (*APIResponse, error)
 	GetWithPagination(path string, fetchAll bool) (*APIResponse, error)

--- a/internal/commands/mock_client_test.go
+++ b/internal/commands/mock_client_test.go
@@ -17,10 +17,13 @@ type MockClient struct {
 	FollowLocationResponse    *client.APIResponse
 	UploadFileResponse        *client.APIResponse
 
+	PatchMultipartResponse *client.APIResponse
+
 	// Errors to return for each method
 	GetError               error
 	PostError              error
 	PatchError             error
+	PatchMultipartError    error
 	PutError               error
 	DeleteError            error
 	GetWithPaginationError error
@@ -32,6 +35,7 @@ type MockClient struct {
 	GetCalls               []MockCall
 	PostCalls              []MockCall
 	PatchCalls             []MockCall
+	PatchMultipartCalls    []MockCall
 	PutCalls               []MockCall
 	DeleteCalls            []MockCall
 	GetWithPaginationCalls []MockCall
@@ -66,6 +70,10 @@ func NewMockClient() *MockClient {
 		},
 		PatchResponse: &client.APIResponse{
 			StatusCode: 200,
+			Data:       map[string]interface{}{},
+		},
+		PatchMultipartResponse: &client.APIResponse{
+			StatusCode: 204,
 			Data:       map[string]interface{}{},
 		},
 		PutResponse: &client.APIResponse{
@@ -113,6 +121,18 @@ func (m *MockClient) Patch(path string, body interface{}) (*client.APIResponse, 
 		return nil, m.PatchError
 	}
 	return m.PatchResponse, nil
+}
+
+func (m *MockClient) PatchMultipart(path, fileField, filePath string, fields map[string]string) (*client.APIResponse, error) {
+	m.PatchMultipartCalls = append(m.PatchMultipartCalls, MockCall{Path: path, Body: map[string]interface{}{
+		"file_field": fileField,
+		"file_path":  filePath,
+		"fields":     fields,
+	}})
+	if m.PatchMultipartError != nil {
+		return nil, m.PatchMultipartError
+	}
+	return m.PatchMultipartResponse, nil
 }
 
 func (m *MockClient) Put(path string, body interface{}) (*client.APIResponse, error) {

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -97,6 +97,76 @@ var userShowCmd = &cobra.Command{
 	},
 }
 
+// User update flags
+var userUpdateName string
+var userUpdateAvatar string
+
+var userUpdateCmd = &cobra.Command{
+	Use:   "update USER_ID",
+	Short: "Update a user",
+	Long:  "Updates a user's details. Requires admin or owner permissions.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		userID := args[0]
+		path := "/users/" + userID + ".json"
+
+		if userUpdateName == "" && userUpdateAvatar == "" {
+			exitWithError(newRequiredFlagError("name or --avatar"))
+		}
+
+		apiClient := getClient()
+
+		if userUpdateAvatar != "" {
+			fields := make(map[string]string)
+			if userUpdateName != "" {
+				fields["user[name]"] = userUpdateName
+			}
+			resp, err := apiClient.PatchMultipart(path, "user[avatar]", userUpdateAvatar, fields)
+			if err != nil {
+				exitWithError(err)
+			}
+
+			breadcrumbs := []response.Breadcrumb{
+				breadcrumb("show", fmt.Sprintf("fizzy user show %s", userID), "View user"),
+				breadcrumb("people", "fizzy user list", "List users"),
+			}
+
+			data := resp.Data
+			if data == nil {
+				data = map[string]interface{}{}
+			}
+			printSuccessWithBreadcrumbs(data, "", breadcrumbs)
+			return
+		}
+
+		body := map[string]interface{}{
+			"user": map[string]interface{}{
+				"name": userUpdateName,
+			},
+		}
+		resp, err := apiClient.Patch(path, body)
+		if err != nil {
+			exitWithError(err)
+		}
+
+		// Build breadcrumbs
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("show", fmt.Sprintf("fizzy user show %s", userID), "View user"),
+			breadcrumb("people", "fizzy user list", "List users"),
+		}
+
+		data := resp.Data
+		if data == nil {
+			data = map[string]interface{}{}
+		}
+		printSuccessWithBreadcrumbs(data, "", breadcrumbs)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(userCmd)
 
@@ -107,4 +177,9 @@ func init() {
 
 	// Show
 	userCmd.AddCommand(userShowCmd)
+
+	// Update
+	userUpdateCmd.Flags().StringVar(&userUpdateName, "name", "", "User's display name")
+	userUpdateCmd.Flags().StringVar(&userUpdateAvatar, "avatar", "", "Path to avatar image file")
+	userCmd.AddCommand(userUpdateCmd)
 }

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/robzolkos/fizzy-cli/internal/client"
+	"github.com/robzolkos/fizzy-cli/internal/errors"
 )
 
 func TestUserList(t *testing.T) {
@@ -58,6 +59,118 @@ func TestUserShow(t *testing.T) {
 		}
 		if mock.GetCalls[0].Path != "/users/user-1.json" {
 			t.Errorf("expected path '/users/user-1.json', got '%s'", mock.GetCalls[0].Path)
+		}
+	})
+}
+
+func TestUserUpdate(t *testing.T) {
+	t.Run("updates user name", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PatchResponse = &client.APIResponse{
+			StatusCode: 204,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		userUpdateName = "New Name"
+		RunTestCommand(func() {
+			userUpdateCmd.Run(userUpdateCmd, []string{"user-1"})
+		})
+		userUpdateName = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.PatchCalls) != 1 {
+			t.Fatalf("expected 1 patch call, got %d", len(mock.PatchCalls))
+		}
+		if mock.PatchCalls[0].Path != "/users/user-1.json" {
+			t.Errorf("expected path '/users/user-1.json', got '%s'", mock.PatchCalls[0].Path)
+		}
+
+		body := mock.PatchCalls[0].Body.(map[string]interface{})
+		userParams := body["user"].(map[string]interface{})
+		if userParams["name"] != "New Name" {
+			t.Errorf("expected name 'New Name', got '%v'", userParams["name"])
+		}
+	})
+
+	t.Run("updates user avatar via multipart", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PatchMultipartResponse = &client.APIResponse{
+			StatusCode: 204,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		userUpdateAvatar = "/path/to/avatar.jpg"
+		RunTestCommand(func() {
+			userUpdateCmd.Run(userUpdateCmd, []string{"user-1"})
+		})
+		userUpdateAvatar = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.PatchMultipartCalls) != 1 {
+			t.Fatalf("expected 1 PatchMultipart call, got %d", len(mock.PatchMultipartCalls))
+		}
+		if mock.PatchMultipartCalls[0].Path != "/users/user-1.json" {
+			t.Errorf("expected path '/users/user-1.json', got '%s'", mock.PatchMultipartCalls[0].Path)
+		}
+	})
+
+	t.Run("updates name and avatar together via multipart", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.PatchMultipartResponse = &client.APIResponse{
+			StatusCode: 204,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		userUpdateName = "New Name"
+		userUpdateAvatar = "/path/to/avatar.jpg"
+		RunTestCommand(func() {
+			userUpdateCmd.Run(userUpdateCmd, []string{"user-1"})
+		})
+		userUpdateName = ""
+		userUpdateAvatar = ""
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.PatchMultipartCalls) != 1 {
+			t.Fatalf("expected 1 PatchMultipart call, got %d", len(mock.PatchMultipartCalls))
+		}
+		// When avatar is provided, should use PatchMultipart (not Patch)
+		if len(mock.PatchCalls) != 0 {
+			t.Errorf("expected 0 Patch calls when avatar is provided, got %d", len(mock.PatchCalls))
+		}
+	})
+
+	t.Run("requires at least one flag", func(t *testing.T) {
+		mock := NewMockClient()
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		userUpdateName = ""
+		userUpdateAvatar = ""
+		RunTestCommand(func() {
+			userUpdateCmd.Run(userUpdateCmd, []string{"user-1"})
+		})
+
+		if result.ExitCode != errors.ExitInvalidArgs {
+			t.Errorf("expected exit code %d, got %d", errors.ExitInvalidArgs, result.ExitCode)
 		}
 	})
 }

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -629,6 +629,8 @@ fizzy tag list [--page N] [--all]
 ```bash
 fizzy user list [--page N] [--all]
 fizzy user show USER_ID
+fizzy user update USER_ID --name "Name"       # Update user name (requires admin/owner)
+fizzy user update USER_ID --avatar /path.jpg  # Update user avatar
 ```
 
 ### Pins


### PR DESCRIPTION
## Summary

- Adds `fizzy user update USER_ID` with `--name` and `--avatar` flags
- Uses JSON PATCH for name-only updates, multipart PATCH when avatar is provided
- Adds `PatchMultipart` method to client interface for multipart form data PATCH requests
- E2E tests use `FIZZY_TEST_USER_ID` env var (tests skip gracefully if unset)
- Unit tests cover: name update, avatar update, name+avatar combo, missing flags error
- E2E tests cover: name update + verify, restore name, avatar upload + verify, name+avatar combo, not-found error