### PR TITLE
Add user deactivate command

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,9 @@ fizzy user show USER_ID
 fizzy user update USER_ID --name "New Name"
 fizzy user update USER_ID --avatar /path/to/avatar.jpg
 fizzy user update USER_ID --name "New Name" --avatar /path/to/avatar.jpg
+
+# Deactivate a user (requires admin/owner permissions)
+fizzy user deactivate USER_ID
 ```
 
 ### Tags

--- a/e2e/tests/user_test.go
+++ b/e2e/tests/user_test.go
@@ -261,3 +261,57 @@ func TestUserUpdate(t *testing.T) {
 		}
 	})
 }
+
+func TestUserDeactivate(t *testing.T) {
+	cfg := harness.LoadConfig()
+	if cfg.UserID == "" {
+		t.Skip("FIZZY_TEST_USER_ID not set, skipping user deactivate tests")
+	}
+
+	h := harness.New(t)
+	userID := cfg.UserID
+
+	t.Run("deactivate non-existent user returns not found", func(t *testing.T) {
+		result := h.Run("user", "deactivate", "non-existent-user-id-12345")
+
+		if result.ExitCode != harness.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d\nstdout: %s", harness.ExitNotFound, result.ExitCode, result.Stdout)
+		}
+
+		if result.Response == nil {
+			t.Fatal("expected JSON response")
+		}
+
+		if result.Response.Success {
+			t.Error("expected success=false")
+		}
+	})
+
+	t.Run("deactivates user", func(t *testing.T) {
+		// First verify the user exists
+		showResult := h.Run("user", "show", userID)
+		if showResult.ExitCode != harness.ExitSuccess {
+			t.Fatalf("test user %s not found, cannot test deactivate: %s", userID, showResult.Stderr)
+		}
+
+		result := h.Run("user", "deactivate", userID)
+
+		if result.ExitCode != harness.ExitSuccess {
+			t.Errorf("expected exit code %d, got %d\nstderr: %s\nstdout: %s", harness.ExitSuccess, result.ExitCode, result.Stderr, result.Stdout)
+		}
+
+		if result.Response == nil {
+			t.Fatal("expected JSON response")
+		}
+
+		if !result.Response.Success {
+			t.Errorf("expected success=true, error: %+v", result.Response.Error)
+		}
+
+		// Verify the user is no longer accessible
+		verifyResult := h.Run("user", "show", userID)
+		if verifyResult.ExitCode != harness.ExitNotFound {
+			t.Errorf("expected deactivated user to return not found, got exit code %d", verifyResult.ExitCode)
+		}
+	})
+}

--- a/internal/commands/user.go
+++ b/internal/commands/user.go
@@ -167,6 +167,34 @@ var userUpdateCmd = &cobra.Command{
 	},
 }
 
+var userDeactivateCmd = &cobra.Command{
+	Use:   "deactivate USER_ID",
+	Short: "Deactivate a user",
+	Long:  "Deactivates a user, removing their access to the account. Requires admin or owner permissions.",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if err := requireAuthAndAccount(); err != nil {
+			exitWithError(err)
+		}
+
+		userID := args[0]
+
+		client := getClient()
+		_, err := client.Delete("/users/" + userID + ".json")
+		if err != nil {
+			exitWithError(err)
+		}
+
+		breadcrumbs := []response.Breadcrumb{
+			breadcrumb("people", "fizzy user list", "List users"),
+		}
+
+		printSuccessWithBreadcrumbs(map[string]interface{}{
+			"deactivated": true,
+		}, "", breadcrumbs)
+	},
+}
+
 func init() {
 	rootCmd.AddCommand(userCmd)
 
@@ -182,4 +210,7 @@ func init() {
 	userUpdateCmd.Flags().StringVar(&userUpdateName, "name", "", "User's display name")
 	userUpdateCmd.Flags().StringVar(&userUpdateAvatar, "avatar", "", "Path to avatar image file")
 	userCmd.AddCommand(userUpdateCmd)
+
+	// Deactivate
+	userCmd.AddCommand(userDeactivateCmd)
 }

--- a/internal/commands/user_test.go
+++ b/internal/commands/user_test.go
@@ -174,3 +174,48 @@ func TestUserUpdate(t *testing.T) {
 		}
 	})
 }
+
+func TestUserDeactivate(t *testing.T) {
+	t.Run("deactivates user by ID", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteResponse = &client.APIResponse{
+			StatusCode: 204,
+			Data:       map[string]interface{}{},
+		}
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			userDeactivateCmd.Run(userDeactivateCmd, []string{"user-1"})
+		})
+
+		if result.ExitCode != 0 {
+			t.Errorf("expected exit code 0, got %d", result.ExitCode)
+		}
+		if len(mock.DeleteCalls) != 1 {
+			t.Fatalf("expected 1 delete call, got %d", len(mock.DeleteCalls))
+		}
+		if mock.DeleteCalls[0].Path != "/users/user-1.json" {
+			t.Errorf("expected path '/users/user-1.json', got '%s'", mock.DeleteCalls[0].Path)
+		}
+	})
+
+	t.Run("returns not found for non-existent user", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.DeleteError = errors.NewNotFoundError("User not found")
+
+		result := SetTestMode(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer ResetTestMode()
+
+		RunTestCommand(func() {
+			userDeactivateCmd.Run(userDeactivateCmd, []string{"non-existent-user"})
+		})
+
+		if result.ExitCode != errors.ExitNotFound {
+			t.Errorf("expected exit code %d, got %d", errors.ExitNotFound, result.ExitCode)
+		}
+	})
+}

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -631,6 +631,7 @@ fizzy user list [--page N] [--all]
 fizzy user show USER_ID
 fizzy user update USER_ID --name "Name"       # Update user name (requires admin/owner)
 fizzy user update USER_ID --avatar /path.jpg  # Update user avatar
+fizzy user deactivate USER_ID                  # Deactivate user (requires admin/owner)
 ```
 
 ### Pins


### PR DESCRIPTION
## Summary
- Adds `fizzy user deactivate USER_ID` command that sends DELETE to `/users/{id}.json`, deactivating the user and removing their account access
- Requires admin or owner permissions
- Unit tests for success and not-found cases
- E2e tests (skipped when `FIZZY_TEST_USER_ID` not set) verify deactivation and that the user becomes inaccessible afterward
- Updated README and SKILL.md