### PR TITLE
Fix accuracy issues across plugin and skill files

### DIFF
--- a/.claude-plugin/hooks/session-start.sh
+++ b/.claude-plugin/hooks/session-start.sh
@@ -21,7 +21,7 @@ else
     cat << 'EOF'
 <hook-output>
 Fizzy plugin: fizzy CLI not found.
-Install: https://github.com/basecamp/fizzy-cli#quick-start
+Install: https://github.com/robzolkos/fizzy-cli#quick-start
 </hook-output>
 EOF
     exit 0
@@ -50,7 +50,7 @@ fi
 context="Fizzy context loaded:"
 
 if [[ -n "$cli_version" ]]; then
-  context+="\n  CLI: v${cli_version}"
+  context+="\n  CLI: ${cli_version}"
 fi
 
 if [[ -n "$account" ]]; then

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "37signals",
     "email": "support@37signals.com"
   },
-  "homepage": "https://github.com/basecamp/fizzy-cli",
-  "repository": "https://github.com/basecamp/fizzy-cli",
+  "homepage": "https://github.com/robzolkos/fizzy-cli",
+  "repository": "https://github.com/robzolkos/fizzy-cli",
   "license": "MIT"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 bin/
+/fizzy
 *.exe
 *.exe~
 *.dll

--- a/skills/fizzy/SKILL.md
+++ b/skills/fizzy/SKILL.md
@@ -256,7 +256,9 @@ All commands support:
 
 | Flag | Description |
 |------|-------------|
+| `--token TOKEN` | API access token |
 | `--account SLUG` | Account slug (for multi-account users) |
+| `--api-url URL` | API base URL (default: https://app.fizzy.do) |
 | `--pretty` | Pretty-print JSON output |
 | `--verbose` | Show request/response details |
 
@@ -477,7 +479,7 @@ fizzy migrate board BOARD_ID --from personal --to team-account \
 ```bash
 fizzy card list [flags]
   --board ID                           # Filter by board
-  --column ID                          # Filter by column ID or pseudo: not-yet, maybe, done
+  --column ID                          # Filter by column ID or pseudo: not-now, maybe, done
   --assignee ID                        # Filter by assignee user ID
   --tag ID                             # Filter by tag ID
   --indexed-by LANE                    # Filter: all, closed, not_now, stalled, postponing_soon, golden
@@ -531,7 +533,7 @@ fizzy card untriage CARD_NUMBER        # Remove from column, back to triage
 #### Actions
 
 ```bash
-fizzy card column CARD_NUMBER --column ID     # Move to column (use column ID or: maybe, not-yet, done)
+fizzy card column CARD_NUMBER --column ID     # Move to column (use column ID or: maybe, not-now, done)
 fizzy card move CARD_NUMBER --to BOARD_ID     # Move card to a different board
 fizzy card assign CARD_NUMBER --user ID       # Toggle user assignment
 fizzy card self-assign CARD_NUMBER            # Toggle current user's assignment
@@ -555,7 +557,7 @@ fizzy card attachments download CARD_NUMBER [INDEX] [--include-comments]  # Down
 
 ### Columns
 
-Boards have pseudo columns by default: `not-yet`, `maybe`, `done`
+Boards have pseudo columns by default: `not-now`, `maybe`, `done`
 
 ```bash
 fizzy column list --board ID


### PR DESCRIPTION
## Summary
- **session-start.sh**: Fix double `v` prefix in version display (`vv3.0.3` -> `v3.0.3`)
- **plugin.json + session-start.sh**: Fix URLs to point to current repo (`robzolkos/fizzy-cli`)
- **SKILL.md**: Standardize pseudo-column names to canonical `not-now` (was inconsistently using `not-yet` in some places)
- **SKILL.md**: Add missing `--token` and `--api-url` to global flags table
- **.gitignore**: Add `/fizzy` to prevent accidentally committing the 14MB compiled binary