### PR TITLE
Lead Quick Start with universal installer instead of Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,24 @@
 ## Quick Start
 
 ```bash
-brew install basecamp/tap/fizzy
+curl -fsSL https://raw.githubusercontent.com/basecamp/fizzy-cli/master/scripts/install.sh | bash
 fizzy setup
 ```
 
-That's it. The setup wizard walks you through configuring your token, selecting your account, and optionally setting a default board. Try `fizzy board list` to verify everything is working.
+That's it. The installer detects your platform and architecture, downloads the right binary, and verifies checksums. The setup wizard then walks you through configuring your token, selecting your account, and optionally setting a default board. Try `fizzy board list` to verify everything is working.
 
 <details>
 <summary>Other installation methods</summary>
+
+**Omarchy/Arch Linux (AUR):**
+```bash
+yay -S fizzy-cli
+```
+
+**Homebrew (macOS):**
+```bash
+brew install basecamp/tap/fizzy
+```
 
 **Scoop (Windows):**
 ```bash
@@ -39,19 +49,9 @@ scoop bucket add basecamp https://github.com/basecamp/homebrew-tap
 scoop install fizzy
 ```
 
-**curl installer:**
-```bash
-curl -fsSL https://raw.githubusercontent.com/basecamp/fizzy-cli/master/scripts/install.sh | bash
-```
-
 **Go install:**
 ```bash
 go install github.com/basecamp/fizzy-cli/cmd/fizzy@latest
-```
-
-**Arch Linux (AUR):**
-```bash
-yay -S fizzy-cli
 ```
 
 **Debian/Ubuntu:**


### PR DESCRIPTION
## Summary

- Promotes the cross-platform `curl` installer to the Quick Start section so the README doesn't default to macOS/Homebrew
- Moves Homebrew into "Other installation methods" alongside Scoop, AUR, etc.
- Reorders alternatives to list Omarchy/Arch Linux (AUR) first

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Quick Start to the cross-platform curl installer so new users on any OS can install Fizzy without Homebrew. Moves Homebrew to "Other installation methods" and reorders alternatives (AUR first); the installer auto-detects platform/architecture, downloads the right binary, and verifies checksums.

<sup>Written for commit b8f7b0c914ea3d6f2d08132d993b3fc3f3f7756e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

