### PR TITLE
Harden workflows against script injection

### DIFF
--- a/.github/prompts/classify-pr.prompt.yml
+++ b/.github/prompts/classify-pr.prompt.yml
@@ -18,23 +18,23 @@ messages:
       When a PR mixes categories: bug > enhancement > documentation.
       Prefer diff evidence over the PR title.
 model: openai/gpt-4o-mini
-responseFormat:
-  type: json_schema
-  json_schema:
-    name: classification
-    strict: true
-    schema:
-      type: object
-      properties:
-        label:
-          type: string
-          enum:
-            - bug
-            - enhancement
-            - documentation
-      required:
-        - label
-      additionalProperties: false
+responseFormat: json_schema
+jsonSchema: |-
+  {
+    "name": "classification",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "label": {
+          "type": "string",
+          "enum": ["bug", "enhancement", "documentation"]
+        }
+      },
+      "required": ["label"],
+      "additionalProperties": false
+    }
+  }
 modelParameters:
-  maxCompletionTokens: 10
+  maxCompletionTokens: 25
   temperature: 0

--- a/.github/workflows/ai-labeler.yml
+++ b/.github/workflows/ai-labeler.yml
@@ -82,7 +82,8 @@ jobs:
           RESPONSE_FILE: ${{ steps.classify.outputs.response-file }}
           PR: ${{ github.event.pull_request.number }}
         run: |
-          LABEL=$(jq -r '.label // empty' "$RESPONSE_FILE" 2>/dev/null || tr -d '[:space:]' < "$RESPONSE_FILE" | tr '[:upper:]' '[:lower:]')
+          LABEL=$(jq -r '.label // empty' "$RESPONSE_FILE" 2>/dev/null || cat "$RESPONSE_FILE")
+          LABEL=$(printf '%s' "$LABEL" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
           case "$LABEL" in
             bug|enhancement|documentation) ;;
             *) echo "Unexpected: $LABEL — skipping"; exit 0 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: write
+  id-token: write
+  security-events: write
+  pull-requests: read
+
 jobs:
   test:
     uses: ./.github/workflows/test.yml


### PR DESCRIPTION
## Summary

- Fix script injection via AI model output in labeler workflow (use response-file, structured JSON output, env vars for PR numbers)
- Move ref names out of shell interpolation in release workflow
- Add environment gate on aur-publish job
- Narrow permissions from workflow-level to per-job

## Context

Security audit of GitHub Actions workflows identified script injection vectors where `${{ }}` expressions are interpolated by the Actions runner before bash executes. This PR eliminates all identified injection paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub Actions workflows to block script injection from model output and crafted ref names. Also tightened permissions and added an environment gate for publish jobs, with improved JSON response handling.

- **Bug Fixes**
  - Labeler: read model output from a response file; enforce strict JSON schema responseFormat; split label extraction so normalization always runs; bump maxCompletionTokens to 25; validate label via jq.
  - Labeler: move PR numbers into env vars instead of shell interpolation to prevent injection.
  - Release: move ref, ref_name, and default_branch into env vars; verify tag ancestry using env-safe values.
  - Permissions: restore top-level security-events:write and add pull-requests:read; keep per-job scoping (contents:write + id-token for release; contents:read for aur-publish) and add an environment gate on aur-publish.

<sup>Written for commit 1b3e49e84481e29d75dce23d71f2f94c61e6463a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

