### PR TITLE
Add direct-push alerting and sensitive-change gate

### DIFF
--- a/.github/workflows/direct-push-alert.yml
+++ b/.github/workflows/direct-push-alert.yml
@@ -1,0 +1,16 @@
+name: Direct Push Alert
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  alert:
+    uses: basecamp/.github/.github/workflows/direct-push-alert.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    permissions:
+      contents: read
+      issues: write

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -1,0 +1,19 @@
+name: Sensitive Change Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gate:
+    uses: basecamp/.github/.github/workflows/sensitive-change-gate.yml@a667bfaac8b33b9c8a6c61019664463a98055995
+    with:
+      extra-patterns: |
+        scripts/publish-aur.sh
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## Summary
- **direct-push-alert**: Detects commits pushed directly to the default branch (bypassing PR flow) and creates/appends to a tracking issue.
- **sensitive-change-gate**: Detects PR changes to control-plane paths (workflows, CODEOWNERS, .goreleaser.yaml, release scripts). Runs in shadow mode — posts an informational comment but does not block.

Both are thin callers to reusable workflows in `basecamp/.github`, pinned to SHA `a667bfaa`.

## Test plan
- [ ] Open a PR touching `.github/workflows/` — verify shadow comment appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add two GitHub Actions to improve change visibility and safety. Direct-push alert tracks commits pushed to the default branch by opening/updating a tracking issue, and sensitive-change gate runs in shadow mode to comment on PRs that touch control-plane files (plus `scripts/publish-aur.sh`) using reusable workflows from `basecamp/.github`.

<sup>Written for commit 0aa67e347faf648c4c6061c0bf44232299d9b4c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

