### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ If system keyring is unavailable (headless servers, containers), set:
 export FIZZY_NO_KEYRING=1
 ```
 
-Credentials will be stored in `~/.config/fizzy/credentials.json` with `0600` permissions.
+Credentials will be stored as individual files in `~/.config/fizzy/credentials/`, each created with `0600` permissions.
 
 ## Supported Versions
 


### PR DESCRIPTION
## Summary

- Add security policy with responsible disclosure instructions, credential storage docs, and supported versions
- Matches the basecamp-cli pattern

Resolves the OpenSSF Scorecard **SecurityPolicy** finding.

## Test plan

- [x] SECURITY.md present and well-formed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SECURITY.md with responsible disclosure (security@37signals.com), Fizzy CLI credential storage via OS keyring, and a corrected file-based fallback at `~/.config/fizzy/credentials/` (enable with `FIZZY_NO_KEYRING=1`; per-file 0600). Defines support policy: security fixes for the latest release only, satisfying the OpenSSF Scorecard SecurityPolicy check.

<sup>Written for commit 28a5fa87eec0f38fffdf3954c24f7d8ce7634ce7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

