### PR TITLE
Add column spacing to styled list output

### DIFF
--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -22,7 +22,10 @@ type Column struct {
 type Columns []Column
 
 // headerStyle is the style for table headers in styled output.
-var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12"))
+var headerStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).PaddingRight(1)
+
+// cellStyle is the style for table data cells in styled output.
+var cellStyle = lipgloss.NewStyle().PaddingRight(1)
 
 // StyledList renders a slice of maps as a styled terminal table.
 func StyledList(data []map[string]any, cols Columns, summary string) string {
@@ -59,9 +62,9 @@ func StyledList(data []map[string]any, cols Columns, summary string) string {
 		Border(lipgloss.NormalBorder()).
 		StyleFunc(func(row, col int) lipgloss.Style {
 			if row == table.HeaderRow {
-				return headerStyle.PaddingRight(1)
+				return headerStyle
 			}
-			return lipgloss.NewStyle().PaddingRight(1)
+			return cellStyle
 		})
 
 	var sb strings.Builder


### PR DESCRIPTION
## Summary
- Adds right padding to table cells in `StyledList` so columns have visible spacing between them
- Affects all list commands (`board list`, `card list`, `user list`, etc.) which were rendering with no gap between columns

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add right padding to `StyledList` header and data cells so columns have clear spacing, fixing cramped output in all list commands (e.g., `board list`, `card list`, `user list`). Pre-build `headerStyle` and `cellStyle` at package level to avoid per-row allocations.

<sup>Written for commit b1dd12677a4059dea080810ad7acfaba8bd15118. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

