### PR TITLE
Fix install script to match actual release asset filenames

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,6 +20,11 @@ case "$OS" in
   *) echo "Unsupported OS: $OS"; exit 1 ;;
 esac
 
+if [ "$OS" = "windows" ] && [ "$ARCH" = "arm64" ]; then
+  echo "Windows ARM64 is not currently supported. See https://github.com/basecamp/fizzy-cli/releases for available builds."
+  exit 1
+fi
+
 # Fetch latest version
 echo "Fetching latest version..."
 VERSION=$(curl -sI "https://github.com/$REPO/releases/latest" | grep -i '^location:' | sed 's/.*tag\///' | tr -d '\r\n' || true)
@@ -29,32 +34,31 @@ if [ -z "$VERSION" ]; then
 fi
 echo "Latest version: $VERSION"
 
-# Download archive
-EXT="tar.gz"
+# Download binary
+BINARY_NAME="fizzy-${OS}-${ARCH}"
 if [ "$OS" = "windows" ]; then
-  EXT="zip"
+  BINARY_NAME="fizzy-${OS}-${ARCH}.exe"
 fi
 
-ARCHIVE="fizzy_${VERSION#v}_${OS}_${ARCH}.${EXT}"
-DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/${ARCHIVE}"
-CHECKSUMS_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt"
+DOWNLOAD_URL="https://github.com/$REPO/releases/download/${VERSION}/${BINARY_NAME}"
+CHECKSUMS_URL="https://github.com/$REPO/releases/download/${VERSION}/SHA256SUMS-${OS}-${ARCH}.txt"
 
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 
-echo "Downloading $ARCHIVE..."
-curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$ARCHIVE"
+echo "Downloading $BINARY_NAME..."
+curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/$BINARY_NAME"
 curl -fsSL "$CHECKSUMS_URL" -o "$TMPDIR/checksums.txt"
 
 # Verify SHA256
 echo "Verifying checksum..."
 cd "$TMPDIR"
-EXPECTED=$(awk -v f="$ARCHIVE" '$2 == f {print $1}' checksums.txt)
+EXPECTED=$(awk '{print $1}' checksums.txt)
 if [ -z "$EXPECTED" ]; then
-  echo "ERROR: Archive not found in checksums file"
+  echo "ERROR: Checksum not found"
   exit 1
 fi
-ACTUAL=$(sha256sum "$ARCHIVE" 2>/dev/null || shasum -a 256 "$ARCHIVE" | awk '{print $1}')
+ACTUAL=$(sha256sum "$BINARY_NAME" 2>/dev/null || shasum -a 256 "$BINARY_NAME" | awk '{print $1}')
 ACTUAL=$(echo "$ACTUAL" | awk '{print $1}')
 if [ "$EXPECTED" != "$ACTUAL" ]; then
   echo "ERROR: Checksum mismatch!"
@@ -64,43 +68,13 @@ if [ "$EXPECTED" != "$ACTUAL" ]; then
 fi
 echo "Checksum verified."
 
-# Verify cosign signature (if cosign available)
-if command -v cosign >/dev/null 2>&1; then
-  SIG_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt.sig"
-  CERT_URL="https://github.com/$REPO/releases/download/${VERSION}/checksums.txt.pem"
-  if curl -fsSL "$SIG_URL" -o checksums.txt.sig 2>/dev/null && \
-     curl -fsSL "$CERT_URL" -o checksums.txt.pem 2>/dev/null; then
-    echo "Verifying cosign signature..."
-    if cosign verify-blob \
-      --certificate checksums.txt.pem \
-      --signature checksums.txt.sig \
-      --certificate-identity-regexp="https://github.com/$REPO/.github/workflows/release.yml@refs/tags/" \
-      --certificate-oidc-issuer="https://token.actions.githubusercontent.com" \
-      checksums.txt 2>/dev/null; then
-      echo "Signature verified."
-    else
-      echo "ERROR: Signature verification failed"
-      exit 1
-    fi
-  fi
-fi
-
-# Extract
-echo "Extracting..."
-if [ "$EXT" = "zip" ]; then
-  unzip -q "$ARCHIVE" -d extract
-else
-  mkdir -p extract
-  tar -xzf "$ARCHIVE" -C extract
-fi
-
 # Install
 mkdir -p "$INSTALL_DIR"
 BINARY="fizzy"
 if [ "$OS" = "windows" ]; then
   BINARY="fizzy.exe"
 fi
-cp "extract/${BINARY}" "$INSTALL_DIR/${BINARY}"
+cp "$BINARY_NAME" "$INSTALL_DIR/${BINARY}"
 chmod +x "$INSTALL_DIR/${BINARY}"
 
 echo ""


### PR DESCRIPTION
## Summary

This aligns install script with _current_ binaries (3.0.3) - the install script will need to be redone once new binaries are created when v4 ships.

- Fix binary filename pattern from `fizzy_{version}_{os}_{arch}.tar.gz` to `fizzy-{os}-{arch}` to match actual release assets
- Fix checksum filename from `checksums.txt` to `SHA256SUMS-{os}-{arch}.txt`
- Remove archive extraction step — assets are bare binaries, not archives
- Reject unsupported Windows ARM64 early with a clear message instead of a cryptic curl 404

Fixes #103

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix install script to match actual release asset names and per-platform checksum files, and remove archive handling. This prevents 404s and ensures checksum verification works.

- **Bug Fixes**
  - Download `fizzy-{os}-{arch}` (or `.exe` on Windows) instead of archived filenames.
  - Verify with `SHA256SUMS-{os}-{arch}.txt` and compare the single hash.
  - Remove extraction; copy the binary directly and set execute permissions.
  - Fail fast on Windows ARM64 with a clear message and link to releases.

<sup>Written for commit 35d39b7092161f9256238dc7fcacce97ed87e675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

