### PR TITLE
Switch CODEOWNERS from sip to cli team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @basecamp/sip
-.goreleaser.yaml      @basecamp/sip
-.github/workflows/    @basecamp/sip
-scripts/release.sh    @basecamp/sip
+* @basecamp/cli
+.goreleaser.yaml      @basecamp/cli
+.github/workflows/    @basecamp/cli
+scripts/release.sh    @basecamp/cli


### PR DESCRIPTION
Reduces review noise for the sip team by routing ownership to the cli team.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch CODEOWNERS from `@basecamp/sip` to `@basecamp/cli` to route reviews to the CLI team and reduce SIP review noise. Updates ownership for the repo default, `.goreleaser.yaml`, `.github/workflows/`, and `scripts/release.sh`.

<sup>Written for commit 10f3e1fe0917720b573ff3e3e49d5b8b01ab7ddd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

