### PR TITLE
Add project scope location for agent skills

### DIFF
--- a/internal/commands/skill.go
+++ b/internal/commands/skill.go
@@ -22,7 +22,8 @@ type SkillLocation struct {
 }
 
 var skillLocations = []SkillLocation{
-	{Name: "Agents (Shared)", Path: "~/.agents/skills/fizzy/SKILL.md"},
+	{Name: "Agents (Global)", Path: "~/.agents/skills/fizzy/SKILL.md"},
+	{Name: "Agents (Project)", Path: ".agents/skills/fizzy/SKILL.md"},
 	{Name: "Claude Code (Global)", Path: "~/.claude/skills/fizzy/SKILL.md"},
 	{Name: "Claude Code (Project)", Path: ".claude/skills/fizzy/SKILL.md"},
 	{Name: "OpenCode (Global)", Path: "~/.config/opencode/skill/fizzy/SKILL.md"},


### PR DESCRIPTION
## What
Add project scope location for agent skills.
https://agentskills.io/client-implementation/adding-skills-support

## Why
AI agent like codex supports this.
https://developers.openai.com/codex/skills#where-to-save-skills

## Testing
Done.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add project-scope location for Agents skills and rename "Agents (Shared)" to "Agents (Global)" for clarity. Skills can now be stored in `.agents/skills/fizzy/SKILL.md` at the project level in addition to the global path `~/.agents/skills/fizzy/SKILL.md`.

<sup>Written for commit 0b393bafeef9e6359ca6bfe3f12bb686a4aa304f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

