### PR TITLE
Keep prereleases out of stable package channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,8 @@ jobs:
     environment: release
     permissions:
       contents: read
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Only publish the normal AUR package for stable tags. Prereleases stay on GitHub Releases.
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -73,9 +73,16 @@ notarize:
 changelog:
   use: github-native
 
+release:
+  prerelease: auto
+  # Keep prerelease tags out of GitHub's latest release/install-script path.
+  make_latest: "{{ if .Prerelease }}false{{ else }}true{{ end }}"
+
 homebrew_casks:
   - name: fizzy
     ids: [default]
+    # Do not update the normal tap for prerelease tags.
+    skip_upload: auto
     repository:
       owner: basecamp
       name: homebrew-tap
@@ -92,6 +99,8 @@ homebrew_casks:
 scoops:
   - name: fizzy
     ids: [default]
+    # Do not update the normal bucket manifest for prerelease tags.
+    skip_upload: auto
     repository:
       owner: basecamp
       name: homebrew-tap

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -76,7 +76,7 @@ changelog:
 release:
   prerelease: auto
   # Keep prerelease tags out of GitHub's latest release/install-script path.
-  make_latest: "{{ if .Prerelease }}false{{ else }}true{{ end }}"
+  make_latest: "{{ if .Prerelease }}false{{ else }}auto{{ end }}"
 
 homebrew_casks:
   - name: fizzy

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,31 @@ Pushing the tag triggers the GitHub Actions release workflow, which:
 
 ## Versioning
 
-Follow [semver](https://semver.org/). Use `v` prefix for tags: `v4.0.0`, `v4.1.0-rc.1`.
+Follow [semver](https://semver.org/). Use `v` prefix for tags: `v4.0.0`, `v4.0.0-beta1`, `v4.1.0-rc.1`.
+
+Stable tags like `v4.0.0` publish to all normal distribution channels. Prerelease tags with a suffix like `-beta1`, `-beta.1`, or `-rc.1` are marked as GitHub prereleases and are not marked as the latest GitHub release.
+
+## Beta / Prerelease Releases
+
+Use a prerelease tag when technical testers need a build before the next stable version:
+
+```bash
+make release VERSION=v4.0.0-beta1
+```
+
+Prerelease behavior is intentionally conservative so existing package-manager users do not upgrade unless they explicitly opt in. Example behavior:
+
+| Surface | Stable tag `v4.0.0` | Prerelease tag `v4.0.0-beta1` |
+|---------|----------------------|--------------------------------|
+| GitHub Releases | Published as a normal release and eligible to be GitHub's latest release. | Published as a GitHub prerelease and explicitly not marked latest. |
+| Release assets | Binaries, archives, checksums, SBOMs, `.deb`, and `.rpm` artifacts are uploaded. | Same artifacts are uploaded for explicit tester download/install. |
+| curl installer | Installs `v4.0.0` once GitHub marks it latest. | Does not install the prerelease via `releases/latest`; testers must download assets explicitly. |
+| Homebrew | Updates the normal `basecamp/tap/fizzy` cask. `brew upgrade fizzy` can move users to `v4.0.0`. | Does not update the normal cask (`skip_upload: auto`). Existing `brew upgrade fizzy` users stay on the latest stable cask. |
+| Scoop | Updates the normal `fizzy` manifest. `scoop update fizzy` can move users to `v4.0.0`. | Does not update the normal manifest (`skip_upload: auto`). Existing Scoop users stay on the latest stable manifest. |
+| AUR | Updates the normal `fizzy-cli` package if `AUR_KEY` is configured. | Skips the AUR publish job. Existing AUR users stay on the latest stable package. |
+| Go install | The git tag exists for users who explicitly request it. | The prerelease tag exists for users who explicitly request it; no package-manager manifest is updated. |
+
+Technical testers can install prereleases explicitly from the GitHub release assets, for example by downloading the asset for their OS/architecture from `https://github.com/basecamp/fizzy-cli/releases/tag/v4.0.0-beta1`.
 
 ## CI Secrets
 
@@ -50,9 +74,9 @@ Follow [semver](https://semver.org/). Use `v` prefix for tags: `v4.0.0`, `v4.1.0
 | Channel | Location | Updated by |
 |---------|----------|------------|
 | GitHub Releases | `basecamp/fizzy-cli/releases` | GoReleaser |
-| Homebrew | `basecamp/homebrew-tap` Casks/fizzy.rb | GoReleaser |
-| Scoop | `basecamp/homebrew-tap` fizzy.json | GoReleaser |
-| AUR | `aur.archlinux.org/packages/fizzy-cli` | `publish-aur.sh` |
+| Homebrew | `basecamp/homebrew-tap` Casks/fizzy.rb | GoReleaser (stable tags only) |
+| Scoop | `basecamp/homebrew-tap` fizzy.json | GoReleaser (stable tags only) |
+| AUR | `aur.archlinux.org/packages/fizzy-cli` | `publish-aur.sh` (stable tags only) |
 | Go install | `go install github.com/basecamp/fizzy-cli/cmd/fizzy@latest` | Go module proxy |
 | curl installer | `scripts/install.sh` | Manual |
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,10 +16,10 @@ Pushing the tag triggers the GitHub Actions release workflow, which:
 3. Signs macOS binaries (Developer ID + notarization)
 4. Signs checksums with cosign (keyless, OIDC)
 5. Generates SBOMs with Syft
-6. Publishes Homebrew cask to `basecamp/homebrew-tap`
-7. Publishes Scoop manifest to `basecamp/homebrew-tap`
-8. Builds .deb and .rpm packages
-9. Publishes to AUR (if `AUR_KEY` configured)
+6. Builds .deb and .rpm packages
+7. For stable tags only, publishes the Homebrew cask to `basecamp/homebrew-tap`
+8. For stable tags only, publishes the Scoop manifest to `basecamp/homebrew-tap`
+9. For stable tags only, publishes to AUR (if `AUR_KEY` configured)
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

This keeps prerelease tags out of the normal package-manager upgrade path while still producing GitHub release artifacts for technical testers.

A stable tag like `v4.0.0` still behaves as a normal release. A prerelease tag like `v4.0.0-beta1` is treated as a tester-only prerelease unless someone explicitly downloads/installs it.

## Surface behavior examples

| Surface | `v4.0.0` stable tag | `v4.0.0-beta1` prerelease tag |
|---------|----------------------|--------------------------------|
| GitHub Releases | Published as a normal release and eligible to become latest. | Published as a GitHub prerelease and explicitly not marked latest. |
| Release assets | Uploads binaries, archives, checksums, SBOMs, `.deb`, and `.rpm` artifacts. | Uploads the same assets for explicit tester download/install. |
| curl installer | Follows GitHub `releases/latest`, so it can install `v4.0.0`. | Does not install the beta via `releases/latest`; testers must download assets explicitly. |
| Homebrew | Updates normal `basecamp/tap/fizzy`; `brew upgrade fizzy` can move users to `v4.0.0`. | Does not update the normal cask (`skip_upload: auto`), so `brew upgrade fizzy` stays on stable. |
| Scoop | Updates normal `fizzy` manifest. | Does not update the normal manifest (`skip_upload: auto`), so normal Scoop upgrades stay on stable. |
| AUR | Updates normal `fizzy-cli` package if `AUR_KEY` is configured. | Skips the AUR publish job, so AUR users stay on stable. |
| Go install | Tag exists for explicit version installs. | Prerelease tag exists for explicit version installs; no package-manager manifest is updated. |

## Changes

- Add GoReleaser `release.prerelease: auto`.
- Set GoReleaser `release.make_latest` false for prerelease tags.
- Add `skip_upload: auto` for Homebrew cask publishing.
- Add `skip_upload: auto` for Scoop manifest publishing.
- Skip the AUR publish job when the tag contains a prerelease suffix (`-`).
- Document the beta/prerelease flow in `RELEASING.md`.

## Validation

- `goreleaser check`
- `actionlint .github/workflows/release.yml`
- YAML parse for `.goreleaser.yaml` and `.github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep prerelease tags out of stable package channels while still shipping GitHub prerelease assets for testers. Stable tags install normally; prerelease tags like `v4.0.0-beta1` are not marked latest and do not update `Homebrew`, `Scoop`, or AUR.

- **Refactors**
  - Set `release.prerelease: auto` and template `make_latest` to false for prerelease tags in `GoReleaser`.
  - Add `skip_upload: auto` to `homebrew_casks` and `scoops` so stable `basecamp/homebrew-tap` manifests aren’t updated on prereleases.
  - Gate the AUR publish job to stable tags only (`!contains(github.ref_name, '-')`) in the release workflow.
  - Document the prerelease flow and examples in `RELEASING.md`.

<sup>Written for commit d1ad54b370808aedc3b7279fa630b17367a88d93. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/155?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

