### PR TITLE
ci: drop approve step from Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,18 +19,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       # CI is the safety gate — auto-merging action updates is circular.
-      - name: Approve patch and minor updates (excluding actions)
-        if: >-
-          (
-            steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-            steps.metadata.outputs.update-type == 'version-update:semver-minor'
-          ) &&
-          steps.metadata.outputs.package-ecosystem != 'github_actions'
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge for patch and minor updates (excluding actions)
         if: >-
           (


### PR DESCRIPTION
## Summary
- Remove the \`gh pr review --approve\` step from \`.github/workflows/dependabot-auto-merge.yml\`. It fails because the repo-level setting *Allow GitHub Actions to create and approve pull requests* is off, which blocks the workflow before the auto-merge step ever runs (e.g. #150).
- \`master\` has no branch protection requiring reviews, so the approve was cosmetic. The \`gh pr merge --auto --squash\` step is unchanged and still gates on CI — the actual safety check.
- Trade-off vs flipping the repo setting (which is what basecamp-cli/hey-cli do): we diverge from the sibling repos and lose the green "Approved" badge on merged Dependabot PRs, but the workflow becomes self-contained and doesn't depend on a setting that can be silently toggled off.

## Test plan
- [ ] Workflow file parses (zizmor / actionlint in CI).
- [ ] After merging, when the next Dependabot PR opens, confirm \`auto-merge\` job succeeds and \`gh pr view <N> --json autoMergeRequest\` shows auto-merge enabled with squash.
- [ ] Once required CI checks pass on that Dependabot PR, GitHub merges it automatically with no manual approve.
- [ ] Backfill #150: re-trigger by close+reopen, or run \`gh pr merge 150 --auto --squash\` once this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the `gh pr review --approve` step from `.github/workflows/dependabot-auto-merge.yml` to stop failures when action approvals are disallowed and restore Dependabot auto-merge. The `gh pr merge --auto --squash` step is unchanged and still waits for required CI.

<sup>Written for commit 35bb4a7fb3ec1707128aae2b96eddb192cb1738a. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/156?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

