### PR TITLE
Migrate webhook commands to SDK

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -655,20 +655,6 @@ func printSuccess(data any) {
 	}
 }
 
-func printSuccessWithLocation(location string) {
-	switch out.EffectiveFormat() {
-	case output.FormatStyled:
-		writeOutputString(renderHumanData(nil, location, false))
-		captureResponse()
-	case output.FormatMarkdown:
-		writeOutputString(renderHumanData(nil, location, true))
-		captureResponse()
-	default:
-		recordOutputError(out.OK(nil, output.WithContext("location", location)))
-		captureResponse()
-	}
-}
-
 // breadcrumb creates a single breadcrumb.
 func breadcrumb(action, cmd, description string) Breadcrumb {
 	return Breadcrumb{Action: action, Cmd: cmd, Description: description}

--- a/internal/commands/webhook.go
+++ b/internal/commands/webhook.go
@@ -268,7 +268,7 @@ var webhookCreateCmd = &cobra.Command{
 			SubscribedActions: webhookCreateActions,
 		}
 
-		raw, _, err := ac.Webhooks().Create(cmd.Context(), boardID, req)
+		raw, resp, err := ac.Webhooks().Create(cmd.Context(), boardID, req)
 		if err != nil {
 			return convertSDKError(err)
 		}
@@ -287,7 +287,11 @@ var webhookCreateCmd = &cobra.Command{
 			}
 		}
 
-		printMutation(data, "", breadcrumbs)
+		if location := resp.Headers.Get("Location"); location != "" {
+			printMutationWithLocation(data, location, breadcrumbs)
+		} else {
+			printMutation(data, "", breadcrumbs)
+		}
 		return nil
 	},
 }
@@ -394,8 +398,14 @@ var webhookReactivateCmd = &cobra.Command{
 		webhookID := args[0]
 
 		ac := getSDK()
-		if _, err := ac.Webhooks().Activate(cmd.Context(), boardID, webhookID); err != nil {
+		resp, err := ac.Webhooks().Activate(cmd.Context(), boardID, webhookID)
+		if err != nil {
 			return convertSDKError(err)
+		}
+
+		data := normalizeAny(resp.Data)
+		if data == nil {
+			data = map[string]any{"id": webhookID, "active": true}
 		}
 
 		breadcrumbs := []Breadcrumb{
@@ -403,7 +413,7 @@ var webhookReactivateCmd = &cobra.Command{
 			breadcrumb("webhooks", fmt.Sprintf("fizzy webhook list --board %s", boardID), "List webhooks"),
 		}
 
-		printMutation(map[string]any{}, "", breadcrumbs)
+		printMutation(data, "", breadcrumbs)
 		return nil
 	},
 }

--- a/internal/commands/webhook.go
+++ b/internal/commands/webhook.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/basecamp/fizzy-sdk/go/pkg/generated"
 	"github.com/spf13/cobra"
 )
 
@@ -49,21 +50,40 @@ var webhookListCmd = &cobra.Command{
 			return err
 		}
 
-		client := getClient()
-		path := fmt.Sprintf("/boards/%s/webhooks.json", boardID)
-		if webhookListPage > 0 {
-			path += fmt.Sprintf("?page=%d", webhookListPage)
+		ac := getSDK()
+		var items any
+		var linkNext string
+
+		switch {
+		case webhookListAll:
+			path := fmt.Sprintf("/boards/%s/webhooks.json", boardID)
+			pages, err := ac.GetAll(cmd.Context(), path)
+			if err != nil {
+				return convertSDKError(err)
+			}
+			items = jsonAnySlice(pages)
+		case webhookListPage > 0:
+			path := fmt.Sprintf("/boards/%s/webhooks.json?page=%d", boardID, webhookListPage)
+			resp, err := ac.Get(cmd.Context(), path)
+			if err != nil {
+				return convertSDKError(err)
+			}
+			var list []map[string]any
+			if err := resp.UnmarshalData(&list); err != nil {
+				return convertSDKError(err)
+			}
+			items = toSliceAny(list)
+			linkNext = parseSDKLinkNext(resp)
+		default:
+			data, resp, err := ac.Webhooks().List(cmd.Context(), boardID)
+			if err != nil {
+				return convertSDKError(err)
+			}
+			items = normalizeAny(data)
+			linkNext = parseSDKLinkNext(resp)
 		}
 
-		resp, err := client.GetWithPagination(path, webhookListAll)
-		if err != nil {
-			return err
-		}
-
-		count := 0
-		if arr, ok := resp.Data.([]any); ok {
-			count = len(arr)
-		}
+		count := dataCount(items)
 		summary := fmt.Sprintf("%d webhooks", count)
 		if webhookListAll {
 			summary += " (all)"
@@ -76,7 +96,7 @@ var webhookListCmd = &cobra.Command{
 			breadcrumb("create", fmt.Sprintf("fizzy webhook create --board %s --name \"name\" --url \"url\"", boardID), "Create webhook"),
 		}
 
-		hasNext := resp.LinkNext != ""
+		hasNext := linkNext != ""
 		if hasNext {
 			nextPage := webhookListPage + 1
 			if webhookListPage == 0 {
@@ -85,7 +105,7 @@ var webhookListCmd = &cobra.Command{
 			breadcrumbs = append(breadcrumbs, breadcrumb("next", fmt.Sprintf("fizzy webhook list --board %s --page %d", boardID, nextPage), "Next page"))
 		}
 
-		printListPaginated(resp.Data, webhookColumns, hasNext, resp.LinkNext, webhookListAll, summary, breadcrumbs)
+		printListPaginated(items, webhookColumns, hasNext, linkNext, webhookListAll, summary, breadcrumbs)
 		return nil
 	},
 }
@@ -185,15 +205,17 @@ var webhookShowCmd = &cobra.Command{
 
 		webhookID := args[0]
 
-		client := getClient()
-		resp, err := client.Get(fmt.Sprintf("/boards/%s/webhooks/%s.json", boardID, webhookID))
+		ac := getSDK()
+		raw, _, err := ac.Webhooks().Get(cmd.Context(), boardID, webhookID)
 		if err != nil {
-			return err
+			return convertSDKError(err)
 		}
 
+		data := normalizeAny(raw)
+
 		summary := "Webhook"
-		if wh, ok := resp.Data.(map[string]any); ok {
-			if name, ok := wh["name"].(string); ok {
+		if wh, ok := data.(map[string]any); ok {
+			if name, ok := wh["name"].(string); ok && name != "" {
 				summary = fmt.Sprintf("Webhook: %s", name)
 			}
 		}
@@ -204,7 +226,7 @@ var webhookShowCmd = &cobra.Command{
 			breadcrumb("reactivate", fmt.Sprintf("fizzy webhook reactivate --board %s %s", boardID, webhookID), "Reactivate webhook"),
 		}
 
-		printDetail(resp.Data, summary, breadcrumbs)
+		printDetail(data, summary, breadcrumbs)
 		return nil
 	},
 }
@@ -236,51 +258,33 @@ var webhookCreateCmd = &cobra.Command{
 			return newRequiredFlagError("url")
 		}
 
-		webhookParams := map[string]any{
-			"name": webhookCreateName,
-			"url":  webhookCreateURL,
+		ac := getSDK()
+		req := &generated.CreateWebhookRequest{
+			Name:              webhookCreateName,
+			Url:               webhookCreateURL,
+			SubscribedActions: webhookCreateActions,
 		}
 
-		if len(webhookCreateActions) > 0 {
-			webhookParams["subscribed_actions"] = webhookCreateActions
-		}
-
-		body := map[string]any{
-			"webhook": webhookParams,
-		}
-
-		client := getClient()
-		resp, err := client.Post(fmt.Sprintf("/boards/%s/webhooks.json", boardID), body)
+		raw, _, err := ac.Webhooks().Create(cmd.Context(), boardID, req)
 		if err != nil {
-			return err
+			return convertSDKError(err)
 		}
 
-		if resp.Location != "" {
-			followResp, err := client.FollowLocation(resp.Location)
-			if err == nil && followResp != nil {
-				webhookID := ""
-				if wh, ok := followResp.Data.(map[string]any); ok {
-					if id, ok := wh["id"].(string); ok {
-						webhookID = id
-					}
-				}
+		data := normalizeAny(raw)
+		webhookID := ""
+		if wh, ok := data.(map[string]any); ok {
+			webhookID = getStringField(wh, "id")
+		}
 
-				var breadcrumbs []Breadcrumb
-				if webhookID != "" {
-					breadcrumbs = []Breadcrumb{
-						breadcrumb("show", fmt.Sprintf("fizzy webhook show --board %s %s", boardID, webhookID), "View webhook"),
-						breadcrumb("update", fmt.Sprintf("fizzy webhook update --board %s %s --name \"name\"", boardID, webhookID), "Update webhook"),
-					}
-				}
-
-				printMutationWithLocation(followResp.Data, resp.Location, breadcrumbs)
-				return nil
+		var breadcrumbs []Breadcrumb
+		if webhookID != "" {
+			breadcrumbs = []Breadcrumb{
+				breadcrumb("show", fmt.Sprintf("fizzy webhook show --board %s %s", boardID, webhookID), "View webhook"),
+				breadcrumb("update", fmt.Sprintf("fizzy webhook update --board %s %s --name \"name\"", boardID, webhookID), "Update webhook"),
 			}
-			printSuccessWithLocation(resp.Location)
-			return nil
 		}
 
-		printSuccess(resp.Data)
+		printMutation(data, "", breadcrumbs)
 		return nil
 	},
 }
@@ -307,23 +311,18 @@ var webhookUpdateCmd = &cobra.Command{
 
 		webhookID := args[0]
 
-		webhookParams := make(map[string]any)
-
+		req := &generated.UpdateWebhookRequest{}
 		if webhookUpdateName != "" {
-			webhookParams["name"] = webhookUpdateName
+			req.Name = webhookUpdateName
 		}
 		if len(webhookUpdateActions) > 0 {
-			webhookParams["subscribed_actions"] = webhookUpdateActions
+			req.SubscribedActions = webhookUpdateActions
 		}
 
-		body := map[string]any{
-			"webhook": webhookParams,
-		}
-
-		client := getClient()
-		resp, err := client.Patch(fmt.Sprintf("/boards/%s/webhooks/%s.json", boardID, webhookID), body)
+		ac := getSDK()
+		raw, _, err := ac.Webhooks().Update(cmd.Context(), boardID, webhookID, req)
 		if err != nil {
-			return err
+			return convertSDKError(err)
 		}
 
 		breadcrumbs := []Breadcrumb{
@@ -331,7 +330,7 @@ var webhookUpdateCmd = &cobra.Command{
 			breadcrumb("delete", fmt.Sprintf("fizzy webhook delete --board %s %s", boardID, webhookID), "Delete webhook"),
 		}
 
-		printMutation(resp.Data, "", breadcrumbs)
+		printMutation(normalizeAny(raw), "", breadcrumbs)
 		return nil
 	},
 }
@@ -354,10 +353,9 @@ var webhookDeleteCmd = &cobra.Command{
 			return err
 		}
 
-		client := getClient()
-		_, err = client.Delete(fmt.Sprintf("/boards/%s/webhooks/%s.json", boardID, args[0]))
-		if err != nil {
-			return err
+		ac := getSDK()
+		if _, err := ac.Webhooks().Delete(cmd.Context(), boardID, args[0]); err != nil {
+			return convertSDKError(err)
 		}
 
 		breadcrumbs := []Breadcrumb{
@@ -392,10 +390,9 @@ var webhookReactivateCmd = &cobra.Command{
 
 		webhookID := args[0]
 
-		client := getClient()
-		resp, err := client.Post(fmt.Sprintf("/boards/%s/webhooks/%s/activation.json", boardID, webhookID), nil)
-		if err != nil {
-			return err
+		ac := getSDK()
+		if _, err := ac.Webhooks().Activate(cmd.Context(), boardID, webhookID); err != nil {
+			return convertSDKError(err)
 		}
 
 		breadcrumbs := []Breadcrumb{
@@ -403,7 +400,7 @@ var webhookReactivateCmd = &cobra.Command{
 			breadcrumb("webhooks", fmt.Sprintf("fizzy webhook list --board %s", boardID), "List webhooks"),
 		}
 
-		printMutation(resp.Data, "", breadcrumbs)
+		printMutation(map[string]any{}, "", breadcrumbs)
 		return nil
 	},
 }

--- a/internal/commands/webhook.go
+++ b/internal/commands/webhook.go
@@ -57,6 +57,9 @@ var webhookListCmd = &cobra.Command{
 		switch {
 		case webhookListAll:
 			path := fmt.Sprintf("/boards/%s/webhooks.json", boardID)
+			if webhookListPage > 0 {
+				path += fmt.Sprintf("?page=%d", webhookListPage)
+			}
 			pages, err := ac.GetAll(cmd.Context(), path)
 			if err != nil {
 				return convertSDKError(err)

--- a/internal/commands/webhook_test.go
+++ b/internal/commands/webhook_test.go
@@ -215,7 +215,10 @@ func TestWebhookShow(t *testing.T) {
 		if !result.Response.OK {
 			t.Error("expected success response")
 		}
-		if got := mock.GetWithPaginationCalls[0].Path; got != "/boards/board-1/webhooks/wh-1" {
+		if len(mock.GetCalls) != 1 {
+			t.Fatalf("expected 1 GET call, got %d", len(mock.GetCalls))
+		}
+		if got := mock.GetCalls[0].Path; got != "/boards/board-1/webhooks/wh-1" {
 			t.Errorf("expected path '/boards/board-1/webhooks/wh-1', got '%s'", got)
 		}
 	})
@@ -241,6 +244,7 @@ func TestWebhookCreate(t *testing.T) {
 		mock := NewMockClient()
 		mock.PostResponse = &client.APIResponse{
 			StatusCode: 201,
+			Location:   "/boards/board-1/webhooks/wh-new",
 			Data: map[string]any{
 				"id":          "wh-new",
 				"name":        "My Hook",
@@ -275,6 +279,9 @@ func TestWebhookCreate(t *testing.T) {
 		}
 		if body["url"] != "https://example.com/hook" {
 			t.Errorf("expected url 'https://example.com/hook', got '%v'", body["url"])
+		}
+		if got := result.Response.Context["location"]; got != "/boards/board-1/webhooks/wh-new" {
+			t.Errorf("expected location context, got %v", got)
 		}
 	})
 
@@ -472,7 +479,7 @@ func TestWebhookReactivate(t *testing.T) {
 			},
 		}
 
-		SetTestModeWithSDK(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
 		defer resetTest()
 
@@ -483,6 +490,13 @@ func TestWebhookReactivate(t *testing.T) {
 		assertExitCode(t, err, 0)
 		if mock.PostCalls[0].Path != "/boards/board-1/webhooks/wh-1/activation.json" {
 			t.Errorf("expected path '/boards/board-1/webhooks/wh-1/activation.json', got '%s'", mock.PostCalls[0].Path)
+		}
+		data, ok := result.Response.Data.(map[string]any)
+		if !ok {
+			t.Fatalf("expected response data map, got %T", result.Response.Data)
+		}
+		if data["id"] != "wh-1" || data["active"] != true {
+			t.Fatalf("expected activated webhook data, got %#v", data)
 		}
 	})
 

--- a/internal/commands/webhook_test.go
+++ b/internal/commands/webhook_test.go
@@ -18,9 +18,9 @@ func TestWebhookList(t *testing.T) {
 			},
 		}
 
-		result := SetTestMode(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookListBoard = "board-1"
 		err := webhookListCmd.RunE(webhookListCmd, []string{})
@@ -31,18 +31,18 @@ func TestWebhookList(t *testing.T) {
 			t.Error("expected success response")
 		}
 		if len(mock.GetWithPaginationCalls) != 1 {
-			t.Errorf("expected 1 GetWithPagination call, got %d", len(mock.GetWithPaginationCalls))
+			t.Fatalf("expected 1 GET call, got %d", len(mock.GetWithPaginationCalls))
 		}
-		if mock.GetWithPaginationCalls[0].Path != "/boards/board-1/webhooks.json" {
-			t.Errorf("expected path '/boards/board-1/webhooks.json', got '%s'", mock.GetWithPaginationCalls[0].Path)
+		if got := mock.GetWithPaginationCalls[0].Path; got != "/boards/board-1/webhooks.json" {
+			t.Errorf("expected path '/boards/board-1/webhooks.json', got '%s'", got)
 		}
 	})
 
 	t.Run("requires board", func(t *testing.T) {
 		mock := NewMockClient()
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookListBoard = ""
 		err := webhookListCmd.RunE(webhookListCmd, []string{})
@@ -52,9 +52,9 @@ func TestWebhookList(t *testing.T) {
 
 	t.Run("requires authentication", func(t *testing.T) {
 		mock := NewMockClient()
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookListBoard = "board-1"
 		err := webhookListCmd.RunE(webhookListCmd, []string{})
@@ -70,9 +70,9 @@ func TestWebhookList(t *testing.T) {
 			Data:       []any{},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookListBoard = "board-1"
 		webhookListPage = 3
@@ -81,8 +81,8 @@ func TestWebhookList(t *testing.T) {
 		webhookListPage = 0
 
 		assertExitCode(t, err, 0)
-		if mock.GetWithPaginationCalls[0].Path != "/boards/board-1/webhooks.json?page=3" {
-			t.Errorf("expected path with page=3, got '%s'", mock.GetWithPaginationCalls[0].Path)
+		if got := mock.GetWithPaginationCalls[0].Path; got != "/boards/board-1/webhooks.json?page=3" {
+			t.Errorf("expected path with page=3, got '%s'", got)
 		}
 	})
 }
@@ -178,9 +178,9 @@ func TestWebhookShow(t *testing.T) {
 			},
 		}
 
-		result := SetTestMode(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookShowBoard = "board-1"
 		err := webhookShowCmd.RunE(webhookShowCmd, []string{"wh-1"})
@@ -190,8 +190,8 @@ func TestWebhookShow(t *testing.T) {
 		if !result.Response.OK {
 			t.Error("expected success response")
 		}
-		if mock.GetCalls[0].Path != "/boards/board-1/webhooks/wh-1.json" {
-			t.Errorf("expected path '/boards/board-1/webhooks/wh-1.json', got '%s'", mock.GetCalls[0].Path)
+		if got := mock.GetWithPaginationCalls[0].Path; got != "/boards/board-1/webhooks/wh-1" {
+			t.Errorf("expected path '/boards/board-1/webhooks/wh-1', got '%s'", got)
 		}
 	})
 
@@ -199,9 +199,9 @@ func TestWebhookShow(t *testing.T) {
 		mock := NewMockClient()
 		mock.GetError = errors.NewNotFoundError("Webhook not found")
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookShowBoard = "board-1"
 		err := webhookShowCmd.RunE(webhookShowCmd, []string{"bad-id"})
@@ -216,11 +216,6 @@ func TestWebhookCreate(t *testing.T) {
 		mock := NewMockClient()
 		mock.PostResponse = &client.APIResponse{
 			StatusCode: 201,
-			Location:   "https://api.example.com/boards/board-1/webhooks/wh-new",
-			Data:       map[string]any{"id": "wh-new"},
-		}
-		mock.FollowLocationResponse = &client.APIResponse{
-			StatusCode: 200,
 			Data: map[string]any{
 				"id":          "wh-new",
 				"name":        "My Hook",
@@ -229,9 +224,9 @@ func TestWebhookCreate(t *testing.T) {
 			},
 		}
 
-		result := SetTestMode(mock)
+		result := SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookCreateBoard = "board-1"
 		webhookCreateName = "My Hook"
@@ -250,12 +245,11 @@ func TestWebhookCreate(t *testing.T) {
 		}
 
 		body := mock.PostCalls[0].Body.(map[string]any)
-		webhookParams := body["webhook"].(map[string]any)
-		if webhookParams["name"] != "My Hook" {
-			t.Errorf("expected name 'My Hook', got '%v'", webhookParams["name"])
+		if body["name"] != "My Hook" {
+			t.Errorf("expected name 'My Hook', got '%v'", body["name"])
 		}
-		if webhookParams["url"] != "https://example.com/hook" {
-			t.Errorf("expected url 'https://example.com/hook', got '%v'", webhookParams["url"])
+		if body["url"] != "https://example.com/hook" {
+			t.Errorf("expected url 'https://example.com/hook', got '%v'", body["url"])
 		}
 	})
 
@@ -263,16 +257,12 @@ func TestWebhookCreate(t *testing.T) {
 		mock := NewMockClient()
 		mock.PostResponse = &client.APIResponse{
 			StatusCode: 201,
-			Location:   "https://api.example.com/boards/board-1/webhooks/wh-new",
-		}
-		mock.FollowLocationResponse = &client.APIResponse{
-			StatusCode: 200,
 			Data:       map[string]any{"id": "wh-new"},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookCreateBoard = "board-1"
 		webhookCreateName = "My Hook"
@@ -287,8 +277,10 @@ func TestWebhookCreate(t *testing.T) {
 		assertExitCode(t, err, 0)
 
 		body := mock.PostCalls[0].Body.(map[string]any)
-		webhookParams := body["webhook"].(map[string]any)
-		actions := webhookParams["subscribed_actions"].([]string)
+		actions, ok := body["subscribed_actions"].([]any)
+		if !ok {
+			t.Fatalf("expected subscribed_actions []any, got %T", body["subscribed_actions"])
+		}
 		if len(actions) != 2 || actions[0] != "card_published" || actions[1] != "card_closed" {
 			t.Errorf("expected actions [card_published, card_closed], got %v", actions)
 		}
@@ -296,9 +288,9 @@ func TestWebhookCreate(t *testing.T) {
 
 	t.Run("requires name flag", func(t *testing.T) {
 		mock := NewMockClient()
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookCreateBoard = "board-1"
 		webhookCreateName = ""
@@ -312,9 +304,9 @@ func TestWebhookCreate(t *testing.T) {
 
 	t.Run("requires url flag", func(t *testing.T) {
 		mock := NewMockClient()
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookCreateBoard = "board-1"
 		webhookCreateName = "My Hook"
@@ -338,9 +330,9 @@ func TestWebhookUpdate(t *testing.T) {
 			},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookUpdateBoard = "board-1"
 		webhookUpdateName = "Updated Name"
@@ -349,14 +341,13 @@ func TestWebhookUpdate(t *testing.T) {
 		webhookUpdateName = ""
 
 		assertExitCode(t, err, 0)
-		if mock.PatchCalls[0].Path != "/boards/board-1/webhooks/wh-1.json" {
-			t.Errorf("expected path '/boards/board-1/webhooks/wh-1.json', got '%s'", mock.PatchCalls[0].Path)
+		if mock.PatchCalls[0].Path != "/boards/board-1/webhooks/wh-1" {
+			t.Errorf("expected path '/boards/board-1/webhooks/wh-1', got '%s'", mock.PatchCalls[0].Path)
 		}
 
 		body := mock.PatchCalls[0].Body.(map[string]any)
-		webhookParams := body["webhook"].(map[string]any)
-		if webhookParams["name"] != "Updated Name" {
-			t.Errorf("expected name 'Updated Name', got '%v'", webhookParams["name"])
+		if body["name"] != "Updated Name" {
+			t.Errorf("expected name 'Updated Name', got '%v'", body["name"])
 		}
 	})
 
@@ -367,9 +358,9 @@ func TestWebhookUpdate(t *testing.T) {
 			Data:       map[string]any{"id": "wh-1"},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookUpdateBoard = "board-1"
 		webhookUpdateActions = []string{"card_closed"}
@@ -380,8 +371,10 @@ func TestWebhookUpdate(t *testing.T) {
 		assertExitCode(t, err, 0)
 
 		body := mock.PatchCalls[0].Body.(map[string]any)
-		webhookParams := body["webhook"].(map[string]any)
-		actions := webhookParams["subscribed_actions"].([]string)
+		actions, ok := body["subscribed_actions"].([]any)
+		if !ok {
+			t.Fatalf("expected subscribed_actions []any, got %T", body["subscribed_actions"])
+		}
 		if len(actions) != 1 || actions[0] != "card_closed" {
 			t.Errorf("expected actions [card_closed], got %v", actions)
 		}
@@ -391,9 +384,9 @@ func TestWebhookUpdate(t *testing.T) {
 		mock := NewMockClient()
 		mock.PatchError = errors.NewValidationError("Invalid webhook")
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookUpdateBoard = "board-1"
 		webhookUpdateName = "Test"
@@ -413,17 +406,17 @@ func TestWebhookDelete(t *testing.T) {
 			Data:       map[string]any{},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookDeleteBoard = "board-1"
 		err := webhookDeleteCmd.RunE(webhookDeleteCmd, []string{"wh-1"})
 		webhookDeleteBoard = ""
 
 		assertExitCode(t, err, 0)
-		if mock.DeleteCalls[0].Path != "/boards/board-1/webhooks/wh-1.json" {
-			t.Errorf("expected path '/boards/board-1/webhooks/wh-1.json', got '%s'", mock.DeleteCalls[0].Path)
+		if mock.DeleteCalls[0].Path != "/boards/board-1/webhooks/wh-1" {
+			t.Errorf("expected path '/boards/board-1/webhooks/wh-1', got '%s'", mock.DeleteCalls[0].Path)
 		}
 	})
 
@@ -431,9 +424,9 @@ func TestWebhookDelete(t *testing.T) {
 		mock := NewMockClient()
 		mock.DeleteError = errors.NewNotFoundError("Webhook not found")
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookDeleteBoard = "board-1"
 		err := webhookDeleteCmd.RunE(webhookDeleteCmd, []string{"bad-id"})
@@ -454,9 +447,9 @@ func TestWebhookReactivate(t *testing.T) {
 			},
 		}
 
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookReactivateBoard = "board-1"
 		err := webhookReactivateCmd.RunE(webhookReactivateCmd, []string{"wh-1"})
@@ -470,9 +463,9 @@ func TestWebhookReactivate(t *testing.T) {
 
 	t.Run("requires board", func(t *testing.T) {
 		mock := NewMockClient()
-		SetTestMode(mock)
+		SetTestModeWithSDK(mock)
 		SetTestConfig("token", "account", "https://api.example.com")
-		defer ResetTestMode()
+		defer resetTest()
 
 		webhookReactivateBoard = ""
 		err := webhookReactivateCmd.RunE(webhookReactivateCmd, []string{"wh-1"})

--- a/internal/commands/webhook_test.go
+++ b/internal/commands/webhook_test.go
@@ -85,6 +85,31 @@ func TestWebhookList(t *testing.T) {
 			t.Errorf("expected path with page=3, got '%s'", got)
 		}
 	})
+
+	t.Run("--all honors --page as the start page", func(t *testing.T) {
+		mock := NewMockClient()
+		mock.GetWithPaginationResponse = &client.APIResponse{
+			StatusCode: 200,
+			Data:       []any{},
+		}
+
+		SetTestModeWithSDK(mock)
+		SetTestConfig("token", "account", "https://api.example.com")
+		defer resetTest()
+
+		webhookListBoard = "board-1"
+		webhookListPage = 2
+		webhookListAll = true
+		err := webhookListCmd.RunE(webhookListCmd, []string{})
+		webhookListBoard = ""
+		webhookListPage = 0
+		webhookListAll = false
+
+		assertExitCode(t, err, 0)
+		if got := mock.GetWithPaginationCalls[0].Path; got != "/boards/board-1/webhooks.json?page=2" {
+			t.Errorf("expected --all to start from --page=2, got '%s'", got)
+		}
+	})
 }
 
 func TestWebhookDeliveries(t *testing.T) {


### PR DESCRIPTION
## Summary
- Migrates `webhook show|create|update|delete|reactivate` from the legacy HTTP client (`getClient()`) to the typed `WebhooksService` on the SDK account client.
- `webhook list` uses the typed service for the no-flag case and falls back to `ac.Get` / `ac.GetAll` for `--page` and `--all`, since the SDK's `Webhooks().List` doesn't accept a path. (`webhook deliveries` was already on the SDK and is untouched.)
- Behavior, flags, and CLI surface are unchanged — `SURFACE.txt` doesn't change. The e2e CRUD test in `webhook_test.go` continues to drive the same UX.

## Notes
- Unit tests switched to the `SetTestModeWithSDK` httptest-backed pattern.
- Body assertions updated: SDK posts the typed request directly, so no more `{"webhook": {...}}` wrapper. URL assertions for `get/update/delete` drop the `.json` suffix to match the SDK paths (Rails accepts both forms).
- `Create` no longer needs a Location follow-up — `WebhooksService.Create` returns the full `Webhook` directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates webhook CLI commands from the legacy HTTP client to the typed SDK for better type safety with the same CLI behavior. Also fixes list paging when using `--all` with `--page`.

- **Refactors**
  - Switched to SDK `WebhooksService` for `show`, `create`, `update`, `delete`, and `reactivate`.
  - `list`: uses `Webhooks().List` by default; falls back to `ac.Get`/`ac.GetAll` for `--page`/`--all`.
  - Request/response: removed `"webhook"` body wrapper; dropped `.json` paths; `Create` returns full `Webhook` (no Location follow-up); removed unused `printSuccessWithLocation`.
  - Tests now use `SetTestModeWithSDK`; assertions match new paths/payloads; errors via `convertSDKError`.

- **Bug Fixes**
  - `webhook list --all --page N` now starts from page N when fetching all results; added a unit test to lock this in.

<sup>Written for commit e83f22c8846cd1226495f3abdb513db39f05cb7c. Summary will update on new commits. <a href="https://cubic.dev/pr/basecamp/fizzy-cli/pull/159?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

