### PR TITLE
Bump fizzy-sdk to v0.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26
 
 require (
 	github.com/basecamp/cli v0.2.1
-	github.com/basecamp/fizzy-sdk/go v0.1.3
+	github.com/basecamp/fizzy-sdk/go v0.2.1
 	github.com/charmbracelet/huh v1.0.0
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/term v0.2.2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3v
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
 github.com/basecamp/cli v0.2.1 h1:8GyehPVtsTXla0oOPu4QgXRjwwzJ99prlByvyi+0HRQ=
 github.com/basecamp/cli v0.2.1/go.mod h1:p8tt/DatJ2LAzWO6N6tNfV8x3gF5T3IxDTo+U8FfWPo=
-github.com/basecamp/fizzy-sdk/go v0.1.3 h1:rKlWHsyiEnBp0bWnYoyrV0SIXY6COpGjzCpkywUkI24=
-github.com/basecamp/fizzy-sdk/go v0.1.3/go.mod h1:XvOTc+2/6NaECvb2mVhIMq2pNsl9P2wNqwvybIUtQ2g=
+github.com/basecamp/fizzy-sdk/go v0.2.1 h1:4xRRBQWP0V5rMkppAramn9bSDILl+zY0RD7ax8IDjKQ=
+github.com/basecamp/fizzy-sdk/go v0.2.1/go.mod h1:XvOTc+2/6NaECvb2mVhIMq2pNsl9P2wNqwvybIUtQ2g=
 github.com/catppuccin/go v0.3.0 h1:d+0/YicIq+hSTo5oPuRi5kOpqkVA5tAsU6dNhvRu+aY=
 github.com/catppuccin/go v0.3.0/go.mod h1:8IHJuMGaUUjQM82qBrGNBv7LFq6JI3NnQCF6MOlZjpc=
 github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7 h1:JFgG/xnwFfbezlUnFMJy0nusZvytYysV4SCS2cYbvws=

--- a/internal/commands/column_test.go
+++ b/internal/commands/column_test.go
@@ -13,8 +13,8 @@ func TestColumnList(t *testing.T) {
 		mock.OnGet("/boards/123/columns.json", &client.APIResponse{
 			StatusCode: 200,
 			Data: []any{
-				map[string]any{"id": "1", "name": "To Do"},
-				map[string]any{"id": "2", "name": "In Progress"},
+				map[string]any{"id": "1", "name": "To Do", "color": map[string]any{"name": "Blue", "value": "var(--color-card-1)"}},
+				map[string]any{"id": "2", "name": "In Progress", "color": map[string]any{"name": "Green", "value": "var(--color-card-2)"}},
 			},
 		})
 
@@ -99,8 +99,9 @@ func TestColumnShow(t *testing.T) {
 		mock.GetResponse = &client.APIResponse{
 			StatusCode: 200,
 			Data: map[string]any{
-				"id":   "col-1",
-				"name": "In Progress",
+				"id":    "col-1",
+				"name":  "In Progress",
+				"color": map[string]any{"name": "Blue", "value": "var(--color-card-1)"},
 			},
 		}
 


### PR DESCRIPTION
## Summary
- Bump github.com/basecamp/fizzy-sdk/go to v0.2.1
- Add column command test coverage for object-shaped color responses

## Validation
- GOWORK=off make build
- GOWORK=off make release-check
- Targeted read-path e2e against the real test account: account/user/activity/board/card/column/comment/step/reaction/notification/pin/tag/search list/show output contracts